### PR TITLE
Rename singleTokenMaxOut parameter to singleTokenOut

### DIFF
--- a/balancer-js/README.md
+++ b/balancer-js/README.md
@@ -476,7 +476,7 @@ Builds an exit transaction with exact BPT in and minimum token amounts out based
    * @param bptIn - BPT provided for exiting pool
    * @param slippage - Maximum slippage tolerance in percentage. i.e. 0.05 = 5%
    * @param shouldUnwrapNativeAsset Indicates whether wrapped native asset should be unwrapped after exit.
-   * @param singleTokenMaxOut - Optional: token address that if provided will exit to given token
+   * @param singleTokenOut - Optional: token address that if provided will exit to given token
    * @returns transaction request ready to send with signer.sendTransaction
    */
   buildExitExactBPTIn: (
@@ -484,7 +484,7 @@ Builds an exit transaction with exact BPT in and minimum token amounts out based
     bptIn: string,
     slippage: string,
     shouldUnwrapNativeAsset?: boolean,
-    singleTokenMaxOut?: string
+    singleTokenOut?: string
   ) => Promise<ExitExactBPTInAttributes>;
 ```
 

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -272,7 +272,7 @@ export class Pools implements Findable<PoolWithMethods> {
           bptIn: string,
           slippage: string,
           shouldUnwrapNativeAsset = false,
-          singleTokenMaxOut?: string
+          singleTokenOut?: string
         ) => {
           if (concerns.exit.buildExitExactBPTIn) {
             return concerns.exit.buildExitExactBPTIn({
@@ -282,7 +282,7 @@ export class Pools implements Findable<PoolWithMethods> {
               slippage,
               shouldUnwrapNativeAsset,
               wrappedNativeAsset,
-              singleTokenMaxOut,
+              singleTokenOut,
             });
           } else {
             throw 'ExitExactBPTIn not supported';

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.spec.ts
@@ -42,7 +42,7 @@ describe('Composable Stable Pool exits', () => {
         errorMessage = (error as Error).message;
       }
       expect(errorMessage).to.eql(
-        'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+        'shouldUnwrapNativeAsset and singleTokenOut should not have conflicting values'
       );
     });
     it('should return correct attributes for exiting', async () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/linear/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/linear/exit.concern.ts
@@ -14,7 +14,7 @@ export class LinearPoolExit implements ExitConcern {
     slippage,
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
-    singleTokenMaxOut,
+    singleTokenOut,
   }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     // TODO implementation
     console.log(
@@ -24,7 +24,7 @@ export class LinearPoolExit implements ExitConcern {
       slippage,
       shouldUnwrapNativeAsset,
       wrappedNativeAsset,
-      singleTokenMaxOut
+      singleTokenOut
     );
     throw new Error('To be implemented');
   };

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.integration.spec.ts
@@ -51,7 +51,7 @@ describe('MetaStablePool - Exit Concern Integration Tests', async () => {
       signerAddress = await signer.getAddress();
     });
     context('buildExitExactBPTIn', async () => {
-      it('should work with single token maxed out', async () => {
+      it('should work with single token out', async () => {
         const bptIn = parseFixed('10', BPT_DECIMALS).toString();
         const slippage = '0';
         const { to, data, minAmountsOut, expectedAmountsOut } =

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.spec.ts
@@ -41,7 +41,7 @@ describe('MetaStablePool - Exit Unit Tests', () => {
       errorMessage = (error as Error).message;
     }
     expect(errorMessage).to.eql(
-      'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+      'shouldUnwrapNativeAsset and singleTokenOut should not have conflicting values'
     );
   });
   it('should automatically sort tokens/amounts in correct order', async () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -51,7 +51,7 @@ describe('StablePool', async () => {
       signerAddress = await signer.getAddress();
     });
     context('buildExitExactBPTIn', async () => {
-      it('should work with single token maxed out', async () => {
+      it('should work with single token out', async () => {
         const bptIn = parseFixed('10', BPT_DECIMALS).toString();
         const slippage = '0';
         const { to, data, minAmountsOut, expectedAmountsOut } =

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
@@ -41,7 +41,7 @@ describe('StablePool exits', () => {
       errorMessage = (error as Error).message;
     }
     expect(errorMessage).to.eql(
-      'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+      'shouldUnwrapNativeAsset and singleTokenOut should not have conflicting values'
     );
   });
   it('should automatically sort tokens/amounts in correct order', async () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/exit.concern.ts
@@ -14,7 +14,7 @@ export class StablePhantomPoolExit implements ExitConcern {
     slippage,
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
-    singleTokenMaxOut,
+    singleTokenOut,
   }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     // TODO implementation
     console.log(
@@ -24,7 +24,7 @@ export class StablePhantomPoolExit implements ExitConcern {
       slippage,
       shouldUnwrapNativeAsset,
       wrappedNativeAsset,
-      singleTokenMaxOut
+      singleTokenOut
     );
     throw new Error('To be implemented');
   };

--- a/balancer-js/src/modules/pools/pool-types/concerns/types.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/types.ts
@@ -40,7 +40,7 @@ export interface ExitConcern {
    * @param slippage Maximum slippage tolerance in percentage. i.e. 0.05 = 5%
    * @param shouldUnwrapNativeAsset Indicates whether wrapped native asset should be unwrapped after exit.
    * @param wrappedNativeAsset Wrapped native asset address for network being used. Required for exiting with native asset.
-   * @param singleTokenMaxOut Optional: token address that if provided will exit to given token
+   * @param singleTokenOut Optional: token address that if provided will exit to given token
    * @returns transaction request ready to send with signer.sendTransaction
    */
   buildExitExactBPTIn?: ({
@@ -50,7 +50,7 @@ export interface ExitConcern {
     slippage,
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
-    singleTokenMaxOut,
+    singleTokenOut,
   }: ExitExactBPTInParameters) => ExitExactBPTInAttributes;
 
   /**
@@ -148,7 +148,7 @@ export interface ExitExactBPTInParameters {
   slippage: string;
   shouldUnwrapNativeAsset: boolean;
   wrappedNativeAsset: string;
-  singleTokenMaxOut?: string;
+  singleTokenOut?: string;
 }
 
 export interface ExitExactBPTInSingleTokenOutParameters {
@@ -158,7 +158,7 @@ export interface ExitExactBPTInSingleTokenOutParameters {
   slippage: string;
   shouldUnwrapNativeAsset: boolean;
   wrappedNativeAsset: string;
-  singleTokenMaxOut: string;
+  singleTokenOut: string;
 }
 
 export interface ExitExactTokensOutParameters {

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.spec.ts
@@ -42,7 +42,7 @@ describe('WeightedPool exits', () => {
       errorMessage = (error as Error).message;
     }
     expect(errorMessage).to.eql(
-      'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+      'shouldUnwrapNativeAsset and singleTokenOut should not have conflicting values'
     );
   });
   it('should automatically sort tokens/amounts in correct order', async () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
@@ -248,9 +248,7 @@ export class WeightedPoolExit implements ExitConcern {
     const { parsedTokens } = parsedPoolInfo;
     let singleTokenOutIndex = -1;
     if (singleTokenOut) {
-      singleTokenOutIndex = parsedTokens.indexOf(
-        singleTokenOut.toLowerCase()
-      );
+      singleTokenOutIndex = parsedTokens.indexOf(singleTokenOut.toLowerCase());
     }
     return {
       ...parsedPoolInfo,

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
@@ -33,7 +33,7 @@ interface SortedValues {
 
 type ExactBPTInSortedValues = SortedValues & {
   scalingFactors: bigint[];
-  singleTokenMaxOutIndex: number;
+  singleTokenOutIndex: number;
 };
 
 type ExactTokensOutSortedValues = SortedValues & {
@@ -50,7 +50,7 @@ type SortValuesParams = {
 };
 
 type SortValuesExactBptInParams = SortValuesParams & {
-  singleTokenMaxOut?: string;
+  singleTokenOut?: string;
 };
 
 type SortValuesExactTokensOutParams = SortValuesParams & {
@@ -74,7 +74,7 @@ export class WeightedPoolExit implements ExitConcern {
    * @param slippage Maximum slippage tolerance in bps i.e. 10000 = 100%, 1 = 0.01%
    * @param shouldUnwrapNativeAsset Set true if the weth should be unwrapped to Eth
    * @param wrappedNativeAsset Address of wrapped native asset for specific network config
-   * @param singleTokenMaxOut The address of the token that will be singled withdrawn in the exit transaction,
+   * @param singleTokenOut The address of the token that will be singled withdrawn in the exit transaction,
    *                          if not passed, the transaction will do a proportional exit where available
    */
   buildExitExactBPTIn = ({
@@ -84,11 +84,11 @@ export class WeightedPoolExit implements ExitConcern {
     slippage,
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
-    singleTokenMaxOut,
+    singleTokenOut,
   }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     this.checkInputsExactBPTIn({
       bptIn,
-      singleTokenMaxOut,
+      singleTokenOut,
       pool,
       shouldUnwrapNativeAsset,
     });
@@ -96,10 +96,10 @@ export class WeightedPoolExit implements ExitConcern {
       pool,
       wrappedNativeAsset,
       shouldUnwrapNativeAsset,
-      singleTokenMaxOut,
+      singleTokenOut,
     });
     const { minAmountsOut, expectedAmountsOut } =
-      sortedValues.singleTokenMaxOutIndex >= 0
+      sortedValues.singleTokenOutIndex >= 0
         ? this.calcTokenOutGivenExactBptIn({
             ...sortedValues,
             bptIn,
@@ -112,10 +112,10 @@ export class WeightedPoolExit implements ExitConcern {
           });
 
     const userData =
-      sortedValues.singleTokenMaxOutIndex >= 0
+      sortedValues.singleTokenOutIndex >= 0
         ? WeightedPoolEncoder.exitExactBPTInForOneTokenOut(
             bptIn,
-            sortedValues.singleTokenMaxOutIndex
+            sortedValues.singleTokenOutIndex
           )
         : WeightedPoolEncoder.exitExactBPTInForTokensOut(bptIn);
 
@@ -177,35 +177,35 @@ export class WeightedPoolExit implements ExitConcern {
   /**
    *  Checks if the input of buildExitExactBPTIn is valid
    * @param bptIn Bpt inserted in the transaction
-   * @param singleTokenMaxOut (optional) the address of the single token that will be withdrawn, if null|undefined, all tokens will be withdrawn proportionally.
+   * @param singleTokenOut (optional) the address of the single token that will be withdrawn, if null|undefined, all tokens will be withdrawn proportionally.
    * @param pool the pool that is being exited
    * @param shouldUnwrapNativeAsset Set true if the weth should be unwrapped to Eth
    */
   checkInputsExactBPTIn = ({
     bptIn,
-    singleTokenMaxOut,
+    singleTokenOut,
     pool,
     shouldUnwrapNativeAsset,
   }: Pick<
     ExitExactBPTInParameters,
-    'bptIn' | 'singleTokenMaxOut' | 'pool' | 'shouldUnwrapNativeAsset'
+    'bptIn' | 'singleTokenOut' | 'pool' | 'shouldUnwrapNativeAsset'
   >): void => {
     if (!bptIn.length || parseFixed(bptIn, 18).isNegative()) {
       throw new BalancerError(BalancerErrorCode.INPUT_OUT_OF_BOUNDS);
     }
     if (
-      singleTokenMaxOut &&
-      singleTokenMaxOut !== AddressZero &&
+      singleTokenOut &&
+      singleTokenOut !== AddressZero &&
       !pool.tokens
         .map((t) => t.address)
-        .some((a) => isSameAddress(a, singleTokenMaxOut))
+        .some((a) => isSameAddress(a, singleTokenOut))
     ) {
       throw new BalancerError(BalancerErrorCode.TOKEN_MISMATCH);
     }
 
-    if (!shouldUnwrapNativeAsset && singleTokenMaxOut === AddressZero)
+    if (!shouldUnwrapNativeAsset && singleTokenOut === AddressZero)
       throw new Error(
-        'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+        'shouldUnwrapNativeAsset and singleTokenOut should not have conflicting values'
       );
 
     // Check if there's any relevant weighted pool info missing
@@ -237,7 +237,7 @@ export class WeightedPoolExit implements ExitConcern {
     pool,
     wrappedNativeAsset,
     shouldUnwrapNativeAsset,
-    singleTokenMaxOut,
+    singleTokenOut,
   }: SortValuesExactBptInParams): ExactBPTInSortedValues => {
     const parsedPoolInfo = parsePoolInfo(
       pool,
@@ -246,15 +246,15 @@ export class WeightedPoolExit implements ExitConcern {
     );
     // Parse pool info into EVM amounts in order to match amountsIn scalling
     const { parsedTokens } = parsedPoolInfo;
-    let singleTokenMaxOutIndex = -1;
-    if (singleTokenMaxOut) {
-      singleTokenMaxOutIndex = parsedTokens.indexOf(
-        singleTokenMaxOut.toLowerCase()
+    let singleTokenOutIndex = -1;
+    if (singleTokenOut) {
+      singleTokenOutIndex = parsedTokens.indexOf(
+        singleTokenOut.toLowerCase()
       );
     }
     return {
       ...parsedPoolInfo,
-      singleTokenMaxOutIndex,
+      singleTokenOutIndex,
     };
   };
   sortValuesExitExactTokensOut = ({
@@ -297,7 +297,7 @@ export class WeightedPoolExit implements ExitConcern {
     upScaledBalances,
     parsedTotalShares,
     parsedSwapFee,
-    singleTokenMaxOutIndex,
+    singleTokenOutIndex,
     bptIn,
     slippage,
     scalingFactors,
@@ -308,7 +308,7 @@ export class WeightedPoolExit implements ExitConcern {
     | 'upScaledBalances'
     | 'parsedTotalShares'
     | 'parsedSwapFee'
-    | 'singleTokenMaxOutIndex'
+    | 'singleTokenOutIndex'
     | 'scalingFactors'
   > &
     Pick<ExitExactBPTInParameters, 'bptIn' | 'slippage'>): {
@@ -317,8 +317,8 @@ export class WeightedPoolExit implements ExitConcern {
   } => {
     // Calculate amount out given BPT in
     const amountOut = SOR.WeightedMaths._calcTokenOutGivenExactBptIn(
-      BigInt(upScaledBalances[singleTokenMaxOutIndex]),
-      BigInt(parsedWeights[singleTokenMaxOutIndex]),
+      BigInt(upScaledBalances[singleTokenOutIndex]),
+      BigInt(parsedWeights[singleTokenOutIndex]),
       BigInt(bptIn),
       BigInt(parsedTotalShares),
       BigInt(parsedSwapFee)
@@ -326,15 +326,15 @@ export class WeightedPoolExit implements ExitConcern {
 
     const downscaledAmountOut = _downscaleDown(
       BigInt(amountOut) - BigInt(1), // The -1 is to solve rounding errors, sometimes the amount comes 1 point lower than expected
-      scalingFactors[singleTokenMaxOutIndex]
+      scalingFactors[singleTokenOutIndex]
     ).toString();
 
     const expectedAmountsOut = Array(parsedTokens.length).fill('0');
     const minAmountsOut = Array(parsedTokens.length).fill('0');
 
-    expectedAmountsOut[singleTokenMaxOutIndex] = downscaledAmountOut;
+    expectedAmountsOut[singleTokenOutIndex] = downscaledAmountOut;
     // Apply slippage tolerance
-    minAmountsOut[singleTokenMaxOutIndex] = subSlippage(
+    minAmountsOut[singleTokenOutIndex] = subSlippage(
       BigNumber.from(downscaledAmountOut),
       BigNumber.from(slippage)
     ).toString();
@@ -353,7 +353,7 @@ export class WeightedPoolExit implements ExitConcern {
     | 'upScaledBalances'
     | 'parsedTotalShares'
     | 'scalingFactors'
-    | 'singleTokenMaxOutIndex'
+    | 'singleTokenOutIndex'
   > &
     Pick<ExitExactBPTInParameters, 'bptIn' | 'slippage'>): {
     minAmountsOut: string[];

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/exitV1.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/exitV1.concern.integration.spec.ts
@@ -54,7 +54,7 @@ describe('Weighted Pool - Exit Integration Test', async () => {
       signerAddress = await signer.getAddress();
     });
     context('buildExitExactBPTIn', async () => {
-      it('should work with single token maxed out', async () => {
+      it('should work with single token out', async () => {
         const bptIn = parseFixed('10', BPT_DECIMALS).toString();
         const slippage = '0';
         const { to, data, minAmountsOut, expectedAmountsOut } =

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -347,7 +347,7 @@ export interface PoolWithMethods extends Pool, Queries.ParamsBuilder {
     bptIn: string,
     slippage: string,
     shouldUnwrapNativeAsset?: boolean,
-    singleTokenMaxOut?: string
+    singleTokenOut?: string
   ) => ExitExactBPTInAttributes;
   buildExitExactTokensOut: (
     exiter: string,


### PR DESCRIPTION
Per Gareth's request `singleTokenMaxOut` was renamed to `singleTokenOut` in order to make it more understandable.