### PR TITLE
fix: coingecko 414

### DIFF
--- a/balancer-js/examples/data/token-prices.ts
+++ b/balancer-js/examples/data/token-prices.ts
@@ -8,12 +8,14 @@ const sdk = new BalancerSDK({ network: 1, rpcUrl: '' });
 const { data } = sdk;
 const dai = '0x6b175474e89094c44da98b954eedeac495271d0f';
 const eth = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+const weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const ohm = '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5';
 const matic = '0x0000000000000000000000000000000000001010';
 const tetuBal = '0x7fc9e0aa043787bfad28e29632ada302c790ce33';
 
 (async () => {
   // It will be just one request to coingecko
-  const ps = [eth, dai, tetuBal, matic, eth, dai, tetuBal, matic].map((t) => data.tokenPrices.find(t));
+  const ps = [eth, weth, dai, ohm, tetuBal, matic, eth, dai, tetuBal, matic].map((t) => data.tokenPrices.find(t));
   const price = await Promise.all(ps);
 
   console.log(price);

--- a/balancer-js/src/lib/utils/debouncer.spec.ts
+++ b/balancer-js/src/lib/utils/debouncer.spec.ts
@@ -84,6 +84,26 @@ describe('Debouncer', () => {
     expect(await p2).to.eql(['second']);
   });
 
+  it('creates a new promise when limit is reached', async () => {
+    let attrs: string[] = [];
+    const asyncFunc = async (asyncAttrs: string[]) => {
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          attrs = asyncAttrs;
+          resolve(attrs);
+        }, 50)
+      );
+    };
+    const subject = new Debouncer<unknown, string>(asyncFunc, 30, 1);
+
+    const p1 = subject.fetch('first');
+    const p2 = subject.fetch('second');
+    expect(attrs).to.eql([]);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(await p1).to.eql(['first']);
+    expect(await p2).to.eql(['second']);
+  });
+
   it('rejects the promise when debounced function fails', async () => {
     const asyncFunc = async (asyncAttrs: string[]) =>
       Promise.reject(asyncAttrs[0]);


### PR DESCRIPTION
Coingecko has a limit of 180 tokens per one request. I added a limit param to the debouncer to make a separate coingecko call  when the limit is reached.