### PR TITLE
Remove @balancer-labs/typechain

### DIFF
--- a/.github/workflows/balancer-js.yaml
+++ b/.github/workflows/balancer-js.yaml
@@ -54,6 +54,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Generate Subgraph Queries
         run: yarn subgraph:generate
+      - name: Generate Typechain
+        run: yarn typechain:generate
       - name: Build
         run: yarn build
 
@@ -76,6 +78,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Generate Subgraph Queries
         run: yarn subgraph:generate
+      - name: Generate Typechain
+        run: yarn typechain:generate
       - name: Compile
         run: yarn build
       - name: Run node in background for integration tests

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -30,6 +30,8 @@ jobs:
           key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --immutable
         if: steps.cache.outputs.cache-hit != 'true'
+      - name: Generate Typechain
+        run: yarn typechain:generate
       - env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/balancer-js/.gitignore
+++ b/balancer-js/.gitignore
@@ -9,3 +9,4 @@ src/subgraph/generated/
 cache/
 balancer-js.iml
 temp/
+src/contracts/

--- a/balancer-js/examples/pools/queries.ts
+++ b/balancer-js/examples/pools/queries.ts
@@ -1,62 +1,73 @@
 /**
  * Shows how to query balancer helper contracts for
  * expected amounts when providing or exiting liquidity from pools
- * 
+ *
  * yarn examples:run ./examples/pools/queries.ts
  */
 
-import { parseEther, formatEther } from '@ethersproject/units'
-import { BalancerSDK, PoolWithMethods } from '@/.'
+import { parseEther, formatEther } from '@ethersproject/units';
+import { BalancerSDK, PoolWithMethods } from '@/.';
 
 const sdk = new BalancerSDK({
   network: 1,
   rpcUrl: 'https://eth-rpc.gateway.pokt.network',
-})
+});
 
 const { pools, balancerContracts: contracts } = sdk;
 
 // Joining with a single token
 const queryJoin = async (pool: PoolWithMethods) => {
-  const token = pool.tokensList[0]
+  const token = pool.tokensList[0];
   const joinExactInQuery = pool.buildQueryJoinExactIn({
-    maxAmountsIn: pool.tokensList.map((t) => parseEther((t === token) ? '1' : '0'))
-  })
+    maxAmountsIn: pool.tokensList.map((t) =>
+      parseEther(t === token ? '1' : '0')
+    ),
+  });
 
-  const response = await contracts.balancerHelpers.queryJoin(...joinExactInQuery)
+  const response = await contracts.balancerHelpers.callStatic.queryJoin(
+    ...joinExactInQuery
+  );
 
-  console.log(`Joining ${pool.poolType}`)
+  console.log(`Joining ${pool.poolType}`);
   console.table({
     tokens: pool.tokensList.map((t) => `${t.slice(0, 6)}...${t.slice(38, 42)}`),
     amountsIn: response.amountsIn.map(formatEther),
     bptOut: formatEther(response.bptOut),
-  });  
-}
+  });
+};
 
 // Exiting to single token
 const queryExit = async (pool: PoolWithMethods) => {
   const exitToSingleToken = pool.buildQueryExitToSingleToken({
     bptIn: parseEther('1'),
-    tokenOut: pool.tokensList[0]
-  })
+    tokenOut: pool.tokensList[0],
+  });
 
-  const response = await contracts.balancerHelpers.queryExit(...exitToSingleToken)
+  const response = await contracts.balancerHelpers.callStatic.queryExit(
+    ...exitToSingleToken
+  );
 
-  console.log(`Exiting ${pool.poolType}`)
+  console.log(`Exiting ${pool.poolType}`);
   console.table({
     tokens: pool.tokensList.map((t) => `${t.slice(0, 6)}...${t.slice(38, 42)}`),
     amountsOut: response.amountsOut.map(formatEther),
     bptIn: formatEther(response.bptIn),
-  })
-}
-
+  });
+};
 
 (async () => {
-  const composableStable = await pools.find('0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d')
-  const weighted = await pools.find('0x25accb7943fd73dda5e23ba6329085a3c24bfb6a000200000000000000000387')
-  const metaStable = await pools.find('0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080')
+  const composableStable = await pools.find(
+    '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d'
+  );
+  const weighted = await pools.find(
+    '0x25accb7943fd73dda5e23ba6329085a3c24bfb6a000200000000000000000387'
+  );
+  const metaStable = await pools.find(
+    '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080'
+  );
 
   for (const pool of [composableStable, weighted, metaStable]) {
-    await queryJoin(pool!)
-    await queryExit(pool!)
+    await queryJoin(pool!);
+    await queryExit(pool!);
   }
-})()
+})();

--- a/balancer-js/examples/pools/weighted/create.ts
+++ b/balancer-js/examples/pools/weighted/create.ts
@@ -1,11 +1,8 @@
-import {
-  Log,
-  TransactionReceipt,
-} from '@ethersproject/providers';
-import { isSameAddress, PoolType } from 'src';
+import { Log, TransactionReceipt } from '@ethersproject/providers';
 import { Interface, LogDescription } from '@ethersproject/abi';
-import { forkSetup } from "@/test/lib/utils";
-import { WeightedPoolFactory__factory } from "@balancer-labs/typechain";
+import { forkSetup } from '@/test/lib/utils';
+import { WeightedPoolFactory__factory } from '@/contracts/factories/WeightedPoolFactory__factory';
+import { isSameAddress, PoolType } from 'src';
 import {
   alchemyRpcUrl,
   blockNumber,
@@ -15,12 +12,25 @@ import {
   tokenAddresses,
   weights,
   swapFee,
-  owner, slots, balances, balancer, signer, provider
-} from "./example-config";
+  owner,
+  slots,
+  balances,
+  balancer,
+  signer,
+  provider,
+} from './example-config';
 
 async function createWeightedPool() {
   const weightedPoolFactory = balancer.pools.poolFactory.of(PoolType.Weighted);
-  await forkSetup(signer, tokenAddresses, slots, balances, alchemyRpcUrl, blockNumber, false);
+  await forkSetup(
+    signer,
+    tokenAddresses,
+    slots,
+    balances,
+    alchemyRpcUrl,
+    blockNumber,
+    false
+  );
   const { to, data } = weightedPoolFactory.create({
     factoryAddress,
     name,
@@ -55,7 +65,7 @@ async function createWeightedPool() {
     })
     .find((parsedLog) => parsedLog?.name === 'PoolCreated');
   if (!poolCreationEvent) return console.error("There's no event");
-  console.log("poolAddress: " + poolCreationEvent.args.pool);
+  console.log('poolAddress: ' + poolCreationEvent.args.pool);
   return poolCreationEvent.args.pool;
 }
 

--- a/balancer-js/examples/pools/weighted/init-join.ts
+++ b/balancer-js/examples/pools/weighted/init-join.ts
@@ -1,22 +1,19 @@
-import createWeightedPool from "./create";
-import { Interface, LogDescription } from "@ethersproject/abi";
-import { Vault__factory, WeightedPool__factory } from "@balancer-labs/typechain";
-import { Contract } from "@ethersproject/contracts";
-import { balancer, provider, signer, tokenAddresses } from "./example-config";
-import { parseFixed } from "@ethersproject/bignumber";
-import { Log, TransactionReceipt } from "@ethersproject/providers";
-import { isSameAddress } from "@/lib/utils";
-import { PoolType } from "@/types";
+import createWeightedPool from './create';
+import { Interface, LogDescription } from '@ethersproject/abi';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+import { WeightedPool__factory } from '@/contracts/factories/WeightedPool__factory';
+import { Contract } from '@ethersproject/contracts';
+import { balancer, provider, signer, tokenAddresses } from './example-config';
+import { parseFixed } from '@ethersproject/bignumber';
+import { Log, TransactionReceipt } from '@ethersproject/providers';
+import { isSameAddress } from '@/lib/utils';
+import { PoolType } from '@/types';
 
 export async function initJoinWeightedPool() {
   const poolAddress = await createWeightedPool;
   const signerAddress = await signer.getAddress();
   const weightedPoolInterface = new Interface(WeightedPool__factory.abi);
-  const pool = new Contract(
-    poolAddress,
-    weightedPoolInterface,
-    provider
-  );
+  const pool = new Contract(poolAddress, weightedPoolInterface, provider);
   const poolId = await pool.getPoolId();
 
   const weightedPoolFactory = balancer.pools.poolFactory.of(PoolType.Weighted);
@@ -30,7 +27,7 @@ export async function initJoinWeightedPool() {
       parseFixed('8000', 6).toString(),
     ],
   });
-  
+
   const tx = await signer.sendTransaction({
     to: initJoinParams.to,
     data: initJoinParams.data,
@@ -49,13 +46,14 @@ export async function initJoinWeightedPool() {
       return vaultInterface.parseLog(log);
     })
     .find((parsedLog) => parsedLog?.name === 'PoolBalanceChanged');
-  if(!poolInitJoinEvent) return console.error("Couldn't find event in the receipt logs");
+  if (!poolInitJoinEvent)
+    return console.error("Couldn't find event in the receipt logs");
   const poolTokens = poolInitJoinEvent.args[2];
   const newBalances = poolInitJoinEvent.args[3];
   const oldBalances = poolInitJoinEvent.args[4];
-  console.log("Pool Token Addresses: " + poolTokens);
-  console.log("Pool new balances(Big Number): " + newBalances);
-  console.log("Pool old balances: " + oldBalances);
+  console.log('Pool Token Addresses: ' + poolTokens);
+  console.log('Pool new balances(Big Number): ' + newBalances);
+  console.log('Pool old balances: ' + oldBalances);
 }
 
-initJoinWeightedPool().then(r => r);
+initJoinWeightedPool().then((r) => r);

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -31,7 +31,7 @@
     "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(. ./.env && echo $ALCHEMY_URL)",
     "node:goerli": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.goerli.ts node --fork $(grep ALCHEMY_URL_GOERLI .env | cut -d '=' -f2 | tail -1) --port 8000",
     "node:polygon": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.polygon.ts node --fork $(grep ALCHEMY_URL_POLYGON .env | cut -d '=' -f2 | tail -1) --port 8137",
-    "postinstall": "npx typechain --target ethers-v5 --out-dir src/contracts './src/lib/abi/Vault.json' './src/lib/abi/WeightedPoolFactory.json' './src/lib/abi/BalancerHelpers.json' './src/lib/abi/LidoRelayer.json' './src/lib/abi/WeightedPool.json'"
+    "typechain:generate": "npx typechain --target ethers-v5 --out-dir src/contracts './src/lib/abi/Vault.json' './src/lib/abi/WeightedPoolFactory.json' './src/lib/abi/BalancerHelpers.json' './src/lib/abi/LidoRelayer.json' './src/lib/abi/WeightedPool.json'"
   },
   "devDependencies": {
     "@ethersproject/solidity": "^5.6.1",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -30,7 +30,8 @@
     "examples:run": "npx ts-node -P tsconfig.testing.json -r tsconfig-paths/register",
     "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(. ./.env && echo $ALCHEMY_URL)",
     "node:goerli": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.goerli.ts node --fork $(grep ALCHEMY_URL_GOERLI .env | cut -d '=' -f2 | tail -1) --port 8000",
-    "node:polygon": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.polygon.ts node --fork $(grep ALCHEMY_URL_POLYGON .env | cut -d '=' -f2 | tail -1) --port 8137"
+    "node:polygon": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.polygon.ts node --fork $(grep ALCHEMY_URL_POLYGON .env | cut -d '=' -f2 | tail -1) --port 8137",
+    "postinstall": "npx typechain --target ethers-v5 --out-dir src/contracts './src/lib/abi/Vault.json' './src/lib/abi/WeightedPoolFactory.json' './src/lib/abi/BalancerHelpers.json' './src/lib/abi/LidoRelayer.json' './src/lib/abi/WeightedPool.json'"
   },
   "devDependencies": {
     "@ethersproject/solidity": "^5.6.1",
@@ -51,7 +52,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
-    "@typechain/ethers-v5": "^7.0.1",
+    "@typechain/ethers-v5": "^10.2.0",
     "@types/chai": "^4.2.12",
     "@types/lodash": "^4.14.177",
     "@types/mocha": "^8.0.3",
@@ -78,12 +79,11 @@
     "ts-mocha": "^9.0.2",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^3.14.1",
-    "typechain": "^5.1.1",
+    "typechain": "^8.1.1",
     "typescript": "^4.0.2"
   },
   "dependencies": {
     "@balancer-labs/sor": "^4.1.1-beta.3",
-    "@balancer-labs/typechain": "^1.0.0",
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.0",
     "@ethersproject/address": "^5.4.0",

--- a/balancer-js/rollup.config.ts
+++ b/balancer-js/rollup.config.ts
@@ -6,8 +6,6 @@ import { terser } from 'rollup-plugin-terser';
 import dts from 'rollup-plugin-dts';
 import pkg from './package.json';
 
-const external = [...Object.keys(pkg.dependencies)];
-
 export default [
   {
     input: 'src/index.ts',
@@ -32,6 +30,7 @@ export default [
           graphql: 'graphql',
           lodash: 'lodash',
           axios: 'axios',
+          ethers: 'ethers',
         },
       },
       { file: pkg.main, format: 'cjs', sourcemap: true },
@@ -53,7 +52,7 @@ export default [
         },
       }),
     ],
-    external,
+    external: [...Object.keys(pkg.dependencies), 'ethers'],
   },
   {
     input: 'src/index.ts',

--- a/balancer-js/rollup.config.ts
+++ b/balancer-js/rollup.config.ts
@@ -6,9 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 import dts from 'rollup-plugin-dts';
 import pkg from './package.json';
 
-const external = [
-  ...Object.keys(pkg.dependencies)
-];
+const external = [...Object.keys(pkg.dependencies)];
 
 export default [
   {
@@ -28,7 +26,6 @@ export default [
           '@ethersproject/abstract-signer': 'abstractSigner',
           '@ethersproject/contracts': 'contracts',
           '@balancer-labs/sor': 'sor',
-          '@balancer-labs/typechain': 'typechain',
           '@ethersproject/providers': 'providers',
           'graphql-request': 'graphqlRequest',
           'json-to-graphql-query': 'jsonToGraphqlQuery',
@@ -49,11 +46,11 @@ export default [
       }),
       terser({
         format: {
-          comments: false
+          comments: false,
         },
         compress: {
-          pure_funcs: ['console.log', 'console.time', 'console.timeEnd']
-        }
+          pure_funcs: ['console.log', 'console.time', 'console.timeEnd'],
+        },
       }),
     ],
     external,

--- a/balancer-js/src/lib/abi/BalancerHelpers.json
+++ b/balancer-js/src/lib/abi/BalancerHelpers.json
@@ -1,0 +1,148 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "_vault",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "minAmountsOut",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.ExitPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "queryExit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "bptIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amountsOut",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "maxAmountsIn",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.JoinPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "queryJoin",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "bptOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amountsIn",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "vault",
+        "outputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/balancer-js/src/lib/abi/LidoRelayer.json
+++ b/balancer-js/src/lib/abi/LidoRelayer.json
@@ -1,0 +1,342 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "vault",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IwstETH",
+                "name": "wstETH",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "enum IVault.SwapKind",
+                "name": "kind",
+                "type": "uint8"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetInIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetOutIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IVault.BatchSwapStep[]",
+                "name": "swaps",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "contract IAsset[]",
+                "name": "assets",
+                "type": "address[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.FundManagement",
+                "name": "funds",
+                "type": "tuple"
+            },
+            {
+                "internalType": "int256[]",
+                "name": "limits",
+                "type": "int256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "batchSwap",
+        "outputs": [
+            {
+                "internalType": "int256[]",
+                "name": "swapAmounts",
+                "type": "int256[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "minAmountsOut",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.ExitPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "exitPool",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getStETH",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getVault",
+        "outputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getWstETH",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "maxAmountsIn",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.JoinPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "joinPool",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "enum IVault.SwapKind",
+                        "name": "kind",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "contract IAsset",
+                        "name": "assetIn",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "contract IAsset",
+                        "name": "assetOut",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IVault.SingleSwap",
+                "name": "singleSwap",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.FundManagement",
+                "name": "funds",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "limit",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "swap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "swapAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/balancer-js/src/lib/abi/Vault.json
+++ b/balancer-js/src/lib/abi/Vault.json
@@ -1,0 +1,1179 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IAuthorizer",
+                "name": "authorizer",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IWETH",
+                "name": "weth",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "pauseWindowDuration",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "bufferPeriodDuration",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "contract IAuthorizer",
+                "name": "newAuthorizer",
+                "type": "address"
+            }
+        ],
+        "name": "AuthorizerChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "ExternalBalanceTransfer",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "contract IFlashLoanRecipient",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "feeAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "FlashLoan",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "delta",
+                "type": "int256"
+            }
+        ],
+        "name": "InternalBalanceChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "paused",
+                "type": "bool"
+            }
+        ],
+        "name": "PausedStateChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "liquidityProvider",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256[]",
+                "name": "deltas",
+                "type": "int256[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256[]",
+                "name": "protocolFeeAmounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "PoolBalanceChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "assetManager",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "cashDelta",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "managedDelta",
+                "type": "int256"
+            }
+        ],
+        "name": "PoolBalanceManaged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "poolAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum IVault.PoolSpecialization",
+                "name": "specialization",
+                "type": "uint8"
+            }
+        ],
+        "name": "PoolRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "relayer",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "approved",
+                "type": "bool"
+            }
+        ],
+        "name": "RelayerApprovalChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "tokenIn",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "contract IERC20",
+                "name": "tokenOut",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "name": "Swap",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            }
+        ],
+        "name": "TokensDeregistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "indexed": false,
+                "internalType": "address[]",
+                "name": "assetManagers",
+                "type": "address[]"
+            }
+        ],
+        "name": "TokensRegistered",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "WETH",
+        "outputs": [
+            {
+                "internalType": "contract IWETH",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "enum IVault.SwapKind",
+                "name": "kind",
+                "type": "uint8"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetInIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetOutIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IVault.BatchSwapStep[]",
+                "name": "swaps",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "contract IAsset[]",
+                "name": "assets",
+                "type": "address[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.FundManagement",
+                "name": "funds",
+                "type": "tuple"
+            },
+            {
+                "internalType": "int256[]",
+                "name": "limits",
+                "type": "int256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "batchSwap",
+        "outputs": [
+            {
+                "internalType": "int256[]",
+                "name": "assetDeltas",
+                "type": "int256[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            }
+        ],
+        "name": "deregisterTokens",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "minAmountsOut",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.ExitPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "exitPool",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IFlashLoanRecipient",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "userData",
+                "type": "bytes"
+            }
+        ],
+        "name": "flashLoan",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            }
+        ],
+        "name": "getActionId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getAuthorizer",
+        "outputs": [
+            {
+                "internalType": "contract IAuthorizer",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getDomainSeparator",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            }
+        ],
+        "name": "getInternalBalance",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "balances",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            }
+        ],
+        "name": "getNextNonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getPausedState",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "paused",
+                "type": "bool"
+            },
+            {
+                "internalType": "uint256",
+                "name": "pauseWindowEndTime",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "bufferPeriodEndTime",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getPool",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "enum IVault.PoolSpecialization",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            }
+        ],
+        "name": "getPoolTokenInfo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "cash",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "managed",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "lastChangeBlock",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "assetManager",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getPoolTokens",
+        "outputs": [
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "balances",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "lastChangeBlock",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getProtocolFeesCollector",
+        "outputs": [
+            {
+                "internalType": "contract ProtocolFeesCollector",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "relayer",
+                "type": "address"
+            }
+        ],
+        "name": "hasApprovedRelayer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IAsset[]",
+                        "name": "assets",
+                        "type": "address[]"
+                    },
+                    {
+                        "internalType": "uint256[]",
+                        "name": "maxAmountsIn",
+                        "type": "uint256[]"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.JoinPoolRequest",
+                "name": "request",
+                "type": "tuple"
+            }
+        ],
+        "name": "joinPool",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "enum IVault.PoolBalanceOpKind",
+                        "name": "kind",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "token",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct IVault.PoolBalanceOp[]",
+                "name": "ops",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "managePoolBalance",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "enum IVault.UserBalanceOpKind",
+                        "name": "kind",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "contract IAsset",
+                        "name": "asset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IVault.UserBalanceOp[]",
+                "name": "ops",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "manageUserBalance",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "enum IVault.SwapKind",
+                "name": "kind",
+                "type": "uint8"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetInIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "assetOutIndex",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IVault.BatchSwapStep[]",
+                "name": "swaps",
+                "type": "tuple[]"
+            },
+            {
+                "internalType": "contract IAsset[]",
+                "name": "assets",
+                "type": "address[]"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.FundManagement",
+                "name": "funds",
+                "type": "tuple"
+            }
+        ],
+        "name": "queryBatchSwap",
+        "outputs": [
+            {
+                "internalType": "int256[]",
+                "name": "",
+                "type": "int256[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "enum IVault.PoolSpecialization",
+                "name": "specialization",
+                "type": "uint8"
+            }
+        ],
+        "name": "registerPool",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "assetManagers",
+                "type": "address[]"
+            }
+        ],
+        "name": "registerTokens",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IAuthorizer",
+                "name": "newAuthorizer",
+                "type": "address"
+            }
+        ],
+        "name": "setAuthorizer",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "paused",
+                "type": "bool"
+            }
+        ],
+        "name": "setPaused",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "relayer",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "approved",
+                "type": "bool"
+            }
+        ],
+        "name": "setRelayerApproval",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolId",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "enum IVault.SwapKind",
+                        "name": "kind",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "contract IAsset",
+                        "name": "assetIn",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "contract IAsset",
+                        "name": "assetOut",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "userData",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct IVault.SingleSwap",
+                "name": "singleSwap",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "fromInternalBalance",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "recipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "toInternalBalance",
+                        "type": "bool"
+                    }
+                ],
+                "internalType": "struct IVault.FundManagement",
+                "name": "funds",
+                "type": "tuple"
+            },
+            {
+                "internalType": "uint256",
+                "name": "limit",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "swap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountCalculated",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/balancer-js/src/lib/abi/WeightedPoolFactory.json
+++ b/balancer-js/src/lib/abi/WeightedPoolFactory.json
@@ -1,0 +1,120 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "vault",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "pool",
+                "type": "address"
+            }
+        ],
+        "name": "PoolCreated",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "internalType": "string",
+                "name": "symbol",
+                "type": "string"
+            },
+            {
+                "internalType": "contract IERC20[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "weights",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "swapFeePercentage",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
+        ],
+        "name": "create",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getPauseConfiguration",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "pauseWindowDuration",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "bufferPeriodDuration",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getVault",
+        "outputs": [
+            {
+                "internalType": "contract IVault",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "pool",
+                "type": "address"
+            }
+        ],
+        "name": "isPoolFromFactory",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/balancer-js/src/modules/contracts/contracts.module.ts
+++ b/balancer-js/src/modules/contracts/contracts.module.ts
@@ -4,14 +4,12 @@ import { Signer } from '@ethersproject/abstract-signer';
 import { ContractAddresses } from '@/types';
 import { Network } from '@/lib/constants/network';
 import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
-import {
-  Vault__factory,
-  Vault,
-  LidoRelayer__factory,
-  LidoRelayer,
-  BalancerHelpers,
-  BalancerHelpers__factory,
-} from '@balancer-labs/typechain';
+import { LidoRelayer__factory } from '@/contracts/factories/LidoRelayer__factory';
+import { LidoRelayer } from '@/contracts/LidoRelayer';
+import { BalancerHelpers } from '@/contracts/BalancerHelpers';
+import { BalancerHelpers__factory } from '@/contracts/factories/BalancerHelpers__factory';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+import { Vault } from '@/contracts/Vault';
 import { Multicall } from './implementations/multicall';
 import { ERC20 } from './implementations/ERC20';
 import { VeBal } from './implementations/veBAL';

--- a/balancer-js/src/modules/pools/factory/weighted/weighted.factory.spec.ts
+++ b/balancer-js/src/modules/pools/factory/weighted/weighted.factory.spec.ts
@@ -9,11 +9,9 @@ import { Interface, LogDescription } from '@ethersproject/abi';
 import { forkSetup } from '@/test/lib/utils';
 import dotenv from 'dotenv';
 import { isSameAddress } from '@/lib/utils';
-import {
-  Vault__factory,
-  WeightedPool__factory,
-  WeightedPoolFactory__factory,
-} from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+import { WeightedPool__factory } from '@/contracts/factories/WeightedPool__factory';
+import { WeightedPoolFactory__factory } from '@/contracts/factories/WeightedPoolFactory__factory';
 import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';

--- a/balancer-js/src/modules/pools/factory/weighted/weighted.factory.ts
+++ b/balancer-js/src/modules/pools/factory/weighted/weighted.factory.ts
@@ -6,14 +6,10 @@ import {
 import { AssetHelpers, parseToBigInt18 } from '@/lib/utils';
 import { TransactionRequest } from '@ethersproject/providers';
 import { PoolFactory } from '@/modules/pools/factory/pool-factory';
-import { FunctionFragment, Interface } from '@ethersproject/abi';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { balancerVault, networkAddresses } from '@/lib/constants/config';
 import { BalancerNetworkConfig } from '@/types';
-import {
-  Vault__factory,
-  WeightedPoolFactory__factory,
-} from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+import { WeightedPoolFactory__factory } from '@/contracts/factories/WeightedPoolFactory__factory';
 import { BigNumberish } from '@ethersproject/bignumber';
 import { WeightedPoolEncoder } from '@/pool-weighted';
 
@@ -52,26 +48,18 @@ export class WeightedFactory implements PoolFactory {
       tokenAddresses,
       weights
     ) as [string[], BigNumberish[]];
-    const params = [
-      name,
-      symbol,
-      sortedTokens,
-      sortedWeights,
-      swapFeeScaled.toString(),
-      owner,
-    ];
-    const weightedPoolInterface = new Interface(
-      WeightedPoolFactory__factory.abi
-    );
-    const createFunctionAbi = WeightedPoolFactory__factory.abi.find(
-      ({ name }) => name === 'create'
-    );
-    if (!createFunctionAbi)
-      throw new BalancerError(BalancerErrorCode.INTERNAL_ERROR_INVALID_ABI);
-    const createFunctionFragment = FunctionFragment.from(createFunctionAbi);
+    const weightedPoolInterface =
+      WeightedPoolFactory__factory.createInterface();
     const encodedFunctionData = weightedPoolInterface.encodeFunctionData(
-      createFunctionFragment,
-      params
+      'create',
+      [
+        name,
+        symbol,
+        sortedTokens,
+        sortedWeights,
+        swapFeeScaled.toString(),
+        owner,
+      ]
     );
     return {
       to: factoryAddress,

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.ts
@@ -1,6 +1,7 @@
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { AddressZero } from '@ethersproject/constants';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+
 import * as SOR from '@balancer-labs/sor';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import {

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.ts
@@ -17,7 +17,7 @@ import { subSlippage } from '@/lib/utils/slippageHelper';
 import { BigNumber } from '@ethersproject/bignumber';
 import { ComposableStablePoolEncoder } from '@/pool-composable-stable';
 import { balancerVault } from '@/lib/constants/config';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { _upscaleArray } from '@/lib/utils/solidityMaths';
 import { Pool } from '@/types';
 

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
@@ -11,7 +11,7 @@ import {
   ExitPoolAttributes,
 } from '../types';
 import { AssetHelpers, isSameAddress, parsePoolInfo } from '@/lib/utils';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { addSlippage, subSlippage } from '@/lib/utils/slippageHelper';
 import { balancerVault } from '@/lib/constants/config';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/join.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/join.concern.ts
@@ -1,5 +1,5 @@
 import * as SOR from '@balancer-labs/sor';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { BigNumber } from '@ethersproject/bignumber';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { balancerVault } from '@/lib/constants/config';

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/exit.concern.ts
@@ -11,7 +11,7 @@ import {
   ExitPoolAttributes,
 } from '../types';
 import { AssetHelpers, isSameAddress, parsePoolInfo } from '@/lib/utils';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { addSlippage, subSlippage } from '@/lib/utils/slippageHelper';
 import { balancerVault } from '@/lib/constants/config';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/join.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/join.concern.ts
@@ -1,5 +1,5 @@
 import { WeightedMaths } from '@balancer-labs/sor';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { BigNumber } from '@ethersproject/bignumber';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { balancerVault } from '@/lib/constants/config';

--- a/balancer-js/src/modules/pools/pools.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pools.integration.spec.ts
@@ -31,7 +31,7 @@ describe('pools module', () => {
         maxAmountsIn: [bn(1), Zero],
       });
 
-      const join = await balancerHelpers.queryJoin(...params);
+      const join = await balancerHelpers.callStatic.queryJoin(...params);
       expect(Number(join.bptOut)).to.be.gt(0);
     });
   });

--- a/balancer-js/src/modules/pools/queries/queries.integration.spec.ts
+++ b/balancer-js/src/modules/pools/queries/queries.integration.spec.ts
@@ -62,7 +62,7 @@ describe('join and exit queries', () => {
         const params = queryParams.buildQueryJoinExactIn({
           maxAmountsIn,
         });
-        const join = await balancerHelpers.queryJoin(...params);
+        const join = await balancerHelpers.callStatic.queryJoin(...params);
         expect(Number(join.bptOut)).to.be.gt(0);
       });
 
@@ -71,7 +71,7 @@ describe('join and exit queries', () => {
           bptOut: bn(1),
           tokenIn: pool.tokensList[0],
         });
-        const join = await balancerHelpers.queryJoin(...params);
+        const join = await balancerHelpers.callStatic.queryJoin(...params);
         expect(Number(join.amountsIn[0])).to.be.gt(0);
         expect(Number(join.amountsIn[1])).to.eq(0);
       });
@@ -81,7 +81,7 @@ describe('join and exit queries', () => {
           bptIn: bn(10),
           tokenOut: pool.tokensList[0],
         });
-        const exit = await balancerHelpers.queryExit(...params);
+        const exit = await balancerHelpers.callStatic.queryExit(...params);
         expect(Number(exit.amountsOut[0])).to.be.gt(0);
         expect(Number(exit.amountsOut[1])).to.eq(0);
       });
@@ -93,7 +93,7 @@ describe('join and exit queries', () => {
         const params = queryParams.buildQueryExitProportionally({
           bptIn: bn(10),
         });
-        const exit = await balancerHelpers.queryExit(...params);
+        const exit = await balancerHelpers.callStatic.queryExit(...params);
         expect(Number(exit.amountsOut[0])).to.be.gt(0);
         expect(Number(exit.amountsOut[1])).to.be.gt(0);
       });
@@ -104,7 +104,7 @@ describe('join and exit queries', () => {
         const params = queryParams.buildQueryExitExactOut({
           minAmountsOut,
         });
-        const exit = await balancerHelpers.queryExit(...params);
+        const exit = await balancerHelpers.callStatic.queryExit(...params);
         expect(Number(exit.amountsOut[0])).to.be.gt(0);
         expect(Number(exit.amountsOut[1])).to.be.gt(0);
       });

--- a/balancer-js/src/modules/relayer/relayer.module.ts
+++ b/balancer-js/src/modules/relayer/relayer.module.ts
@@ -2,7 +2,7 @@ import { JsonRpcSigner } from '@ethersproject/providers';
 import { BigNumberish, BigNumber } from '@ethersproject/bignumber';
 import { Interface } from '@ethersproject/abi';
 import { MaxUint256, WeiPerEther, Zero } from '@ethersproject/constants';
-import { Vault } from '@balancer-labs/typechain';
+import { Vault } from '@/contracts/Vault';
 
 import { Swaps } from '@/modules/swaps/swaps.module';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';

--- a/balancer-js/src/modules/sor/pool-data/onChainData.ts
+++ b/balancer-js/src/modules/sor/pool-data/onChainData.ts
@@ -3,7 +3,7 @@ import { Provider } from '@ethersproject/providers';
 import { SubgraphPoolBase, SubgraphToken } from '@balancer-labs/sor';
 import { Multicaller } from '@/lib/utils/multiCaller';
 import { isSameAddress } from '@/lib/utils';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import { Pool, PoolToken, PoolType } from '@/types';
 
 // TODO: decide whether we want to trim these ABIs down to the relevant functions
@@ -32,7 +32,8 @@ export async function getOnChainBalances<
     // Remove duplicate entries using their names
     Object.fromEntries(
       [
-        ...Vault__factory.abi,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...(Vault__factory.abi as any),
         ...aTokenRateProvider,
         ...weightedPoolAbi,
         ...stablePoolAbi,

--- a/balancer-js/src/modules/swaps/flashSwap/flashSwap.spec.ts
+++ b/balancer-js/src/modules/swaps/flashSwap/flashSwap.spec.ts
@@ -1,6 +1,7 @@
 import { Contract } from '@ethersproject/contracts';
 import { expect } from 'chai';
-import { Vault, Vault__factory } from '@balancer-labs/typechain';
+import { Vault } from '@/contracts/Vault';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import {
   convertSimpleFlashSwapToBatchSwapParameters,
   querySimpleFlashSwap,

--- a/balancer-js/src/modules/swaps/queryBatchSwap.ts
+++ b/balancer-js/src/modules/swaps/queryBatchSwap.ts
@@ -9,7 +9,7 @@ import {
   QueryWithSorInput,
   QueryWithSorOutput,
 } from './types';
-import { Vault } from '@balancer-labs/typechain';
+import { Vault } from '@/contracts/Vault';
 
 /*
  * queryBatchSwap simulates a call to `batchSwap`, returning an array of Vault asset deltas. Calls to `swap` cannot be

--- a/balancer-js/src/modules/swaps/swap_builder/swap_utils.ts
+++ b/balancer-js/src/modules/swaps/swap_builder/swap_utils.ts
@@ -1,4 +1,4 @@
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import BatchRelayerLibraryAbi from '@/lib/abi/BatchRelayerLibrary.json';
 import { JsonFragment } from '@ethersproject/abi';
 import { networkAddresses } from '@/lib/constants/config';
@@ -85,14 +85,14 @@ function relayerResolver(
 }
 
 function swapFragment(relayer: SwapRelayer): JsonFragment[] {
-  let source = Vault__factory.abi;
-  if (relayer.id === Relayers.lido) source = BatchRelayerLibraryAbi;
-
-  const signatures = source.filter(
-    (fn) => fn.name && ['swap', 'batchSwap'].includes(fn.name)
-  );
-
-  return signatures;
+  if (relayer.id === Relayers.lido)
+    return BatchRelayerLibraryAbi.filter(
+      (fn) => fn.name && ['swap', 'batchSwap'].includes(fn.name)
+    );
+  else
+    return Vault__factory.abi.filter(
+      (f) => f.type === 'function' && ['swap', 'batchSwap'].includes(f.name)
+    );
 }
 
 function batchSwapFragment(
@@ -100,20 +100,19 @@ function batchSwapFragment(
   assetOut: string,
   chainId: number
 ): JsonFragment[] {
-  const vaultSignaturesForSwaps = Vault__factory.abi.filter(
-    (fn) => fn.name && ['batchSwap'].includes(fn.name)
-  );
-  const relayerSignaturesForSwaps = BatchRelayerLibraryAbi.filter(
-    (fn) => fn.name && ['batchSwap'].includes(fn.name)
-  );
-  let returnSignatures = vaultSignaturesForSwaps;
   const { tokens, contracts } = networkAddresses(chainId);
   if (tokens.stETH && contracts.lidoRelayer) {
-    if ([assetIn, assetOut].includes(tokens.stETH))
-      returnSignatures = relayerSignaturesForSwaps;
+    if ([assetIn, assetOut].includes(tokens.stETH)) {
+      const relayerSignaturesForSwaps = BatchRelayerLibraryAbi.filter(
+        (fn) => fn.name && ['batchSwap'].includes(fn.name)
+      );
+      return relayerSignaturesForSwaps;
+    }
   }
-
-  return returnSignatures;
+  const vaultSignaturesForSwaps = Vault__factory.abi.filter(
+    (f) => f.type === 'function' && f.name === 'batchSwap'
+  );
+  return vaultSignaturesForSwaps;
 }
 
 export { tokenForSwaps, relayerResolver, swapFragment, batchSwapFragment };

--- a/balancer-js/src/modules/swaps/swaps.module.spec.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.spec.ts
@@ -11,7 +11,7 @@ import {
 import { getNetworkConfig } from '@/modules/sdk.helpers';
 import { mockPool, mockPoolDataService } from '@/test/lib/mockPool';
 import { SwapTransactionRequest, SwapType } from './types';
-import { Vault__factory } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
 import BatchRelayerLibraryAbi from '@/lib/abi/BatchRelayerLibrary.json';
 import { Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';

--- a/balancer-js/src/modules/swaps/swaps.module.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.ts
@@ -1,5 +1,6 @@
 import { SOR, SubgraphPoolBase, SwapInfo, SwapTypes } from '@balancer-labs/sor';
-import { Vault__factory, Vault } from '@balancer-labs/typechain';
+import { Vault__factory } from '@/contracts/factories/Vault__factory';
+import { Vault } from '@/contracts/Vault';
 import {
   BatchSwap,
   QuerySimpleFlashSwapParameters,

--- a/balancer-js/src/modules/swaps/types.ts
+++ b/balancer-js/src/modules/swaps/types.ts
@@ -1,6 +1,6 @@
 import { SwapInfo } from '@balancer-labs/sor';
-import { Vault } from '@balancer-labs/typechain';
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { Vault } from '@/contracts/Vault';
 
 export enum SwapType {
   SwapExactIn,

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -514,11 +514,6 @@
   dependencies:
     isomorphic-fetch "^2.2.1"
 
-"@balancer-labs/typechain@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/typechain/-/typechain-1.0.0.tgz#823eb13b9e166f7b50334c9d70d9ade81344f5c9"
-  integrity sha512-/fWxh4UgmHxtRt5e1anVeF8COo6FBNF28X8bd0/55SIdRDyaW7TMC7K4Jbuy58IcaERmEqi089lABlEgoeiWTQ==
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -1495,6 +1490,14 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@morgan-stanley/ts-mocking-bird@^0.6.2":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@morgan-stanley/ts-mocking-bird/-/ts-mocking-bird-0.6.4.tgz#2e4b60d42957bab3b50b67dbf14c3da2f62a39f7"
+  integrity sha512-57VJIflP8eR2xXa9cD1LUawh+Gh+BVQfVu0n6GALyg/AqV/Nz25kDRvws3i9kIe1PTrbsZZOYpsYp6bXPd6nVA==
+  dependencies:
+    lodash "^4.17.16"
+    uuid "^7.0.3"
+
 "@noble/hashes@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
@@ -1937,10 +1940,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
-"@typechain/ethers-v5@^7.0.1":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-7.2.0.tgz#d559cffe0efe6bdbc20e644b817f6fa8add5e8f8"
-  integrity sha512-jfcmlTvaaJjng63QsT49MT6R1HFhtO/TBMWbyzPFSzMmVIqb2tL6prnKBs4ZJrSvmgIXWy+ttSjpaxCTq8D/Tw==
+"@typechain/ethers-v5@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-10.2.0.tgz#68f5963efb5214cb2d881477228e4b5b315473e1"
+  integrity sha512-ikaq0N/w9fABM+G01OFmU3U3dNnyRwEahkdvi9mqy1a3XwKiPZaF/lu54OcNaEWnpvEYyhhS0N7buCtLQqC92w==
   dependencies:
     lodash "^4.17.15"
     ts-essentials "^7.0.1"
@@ -2310,19 +2313,15 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-array-back@^1.0.3, array-back@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
-  integrity sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==
-  dependencies:
-    typical "^2.6.0"
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
-array-back@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
-  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
-  dependencies:
-    typical "^2.6.1"
+array-back@^4.0.1, array-back@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -2930,14 +2929,25 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-command-line-args@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-4.0.7.tgz#f8d1916ecb90e9e121eda6428e41300bfb64cc46"
-  integrity sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==
+command-line-args@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
   dependencies:
-    array-back "^2.0.0"
-    find-replace "^1.0.3"
-    typical "^2.6.1"
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.3.tgz#428fa5acde6a838779dfa30e44686f4b6761d957"
+  integrity sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==
+  dependencies:
+    array-back "^4.0.2"
+    chalk "^2.4.2"
+    table-layout "^1.0.2"
+    typical "^5.2.0"
 
 commander@3.0.2:
   version "3.0.2"
@@ -3098,6 +3108,11 @@ deep-eql@^4.1.2:
   integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
   dependencies:
     type-detect "^4.0.0"
+
+deep-extend@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -3627,13 +3642,12 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-replace@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-1.0.3.tgz#b88e7364d2d9c959559f388c66670d6130441fa0"
-  integrity sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
   dependencies:
-    array-back "^1.0.4"
-    test-value "^2.1.0"
+    array-back "^3.0.1"
 
 find-up@5.0.0:
   version "5.0.0"
@@ -3795,6 +3809,18 @@ glob@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4560,6 +4586,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -4575,7 +4606,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5229,6 +5260,11 @@ prettier@^2.1.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
+prettier@^2.3.1:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -5309,6 +5345,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
@@ -5727,6 +5768,11 @@ string-env-interpolation@1.0.1, string-env-interpolation@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
+string-format@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
+  integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
+
 "string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -5815,6 +5861,16 @@ swap-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+table-layout@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 table@^6.0.9:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
@@ -5835,14 +5891,6 @@ terser@^5.0.0:
     acorn "^8.5.0"
     commander "^2.20.0"
     source-map-support "~0.5.20"
-
-test-value@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
-  integrity sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==
-  dependencies:
-    array-back "^1.0.3"
-    typical "^2.6.0"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -5894,6 +5942,17 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-command-line-args@^2.2.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/ts-command-line-args/-/ts-command-line-args-2.4.2.tgz#b4815b23c35f8a0159d4e69e01012d95690bc448"
+  integrity sha512-mJLQQBOdyD4XI/ZWQY44PIdYde47JhV2xl380O7twPkTQ+Y5vFDHsk8LOeXKuz7dVY5aDCfAzRarNfSqtKOkQQ==
+  dependencies:
+    "@morgan-stanley/ts-mocking-bird" "^0.6.2"
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-usage "^6.1.0"
+    string-format "^2.0.0"
 
 ts-essentials@^7.0.1:
   version "7.0.3"
@@ -6021,20 +6080,20 @@ type-fest@^0.7.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
-typechain@^5.1.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/typechain/-/typechain-5.2.0.tgz#10525a44773a34547eb2eed8978cb72c0a39a0f4"
-  integrity sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==
+typechain@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-8.1.1.tgz#9c2e8012c2c4c586536fc18402dcd7034c4ff0bd"
+  integrity sha512-uF/sUvnXTOVF2FHKhQYnxHk4su4JjZR8vr4mA2mBaRwHTbwh0jIlqARz9XJr1tA0l7afJGvEa1dTSi4zt039LQ==
   dependencies:
     "@types/prettier" "^2.1.1"
-    command-line-args "^4.0.7"
-    debug "^4.1.1"
+    debug "^4.3.1"
     fs-extra "^7.0.0"
-    glob "^7.1.6"
+    glob "7.1.7"
     js-sha3 "^0.8.0"
     lodash "^4.17.15"
     mkdirp "^1.0.4"
-    prettier "^2.1.2"
+    prettier "^2.3.1"
+    ts-command-line-args "^2.2.0"
     ts-essentials "^7.0.1"
 
 typescript@^4.0.2:
@@ -6042,10 +6101,15 @@ typescript@^4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-typical@^2.6.0, typical@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
-  integrity sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"
@@ -6121,6 +6185,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.2:
   version "8.3.2"
@@ -6216,6 +6285,14 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
 
 workerpool@6.1.0:
   version "6.1.0"


### PR DESCRIPTION
`@balancer-labs/typechain` is removed in favour of generating Typechain artifacts directly.
* postbuild hook runs typechain command to generate up to date bindings
* Replaced all references to @balancer-labs/typechain with new `./src/contracts` artifacts