### PR TITLE
fix: handle missing token price in APRs

### DIFF
--- a/balancer-js/src/modules/data/index.ts
+++ b/balancer-js/src/modules/data/index.ts
@@ -135,6 +135,21 @@ export class Data implements BalancerDataRepositories {
       });
     }
 
+    // Hardcoding gnosis chain block time to 5 sec.
+    if (networkConfig.chainId === 100) {
+      const blockDayAgo = async () => {
+        const blockNumber = await provider.getBlockNumber();
+        return blockNumber - 17280;
+      };
+
+      this.yesterdaysPools = new PoolsSubgraphRepository({
+        url: networkConfig.urls.subgraph,
+        chainId: networkConfig.chainId,
+        blockHeight: blockDayAgo,
+        query: subgraphQuery,
+      });
+    }
+
     const tokenAddresses = initialCoingeckoList
       .filter((t) => t.chainId == networkConfig.chainId)
       .map((t) => t.address);

--- a/balancer-js/src/modules/data/token-prices/provider.ts
+++ b/balancer-js/src/modules/data/token-prices/provider.ts
@@ -17,7 +17,7 @@ export class TokenPriceProvider implements Findable<Price> {
           throw new Error('Price not found');
         }
       } catch (err) {
-        console.error(`Coingecko API error: ${err}`);
+        console.log(`Coingecko API error: ${err}`);
         price = await this.subgraphRepository.find(address);
       }
     } catch (err) {

--- a/balancer-js/src/modules/pools/apr/apr.ts
+++ b/balancer-js/src/modules/pools/apr/apr.ts
@@ -188,8 +188,14 @@ export class PoolApr {
           return 0;
         }
 
-        const weight = await getWeight(token);
-        return Math.round(aprs[idx] * weight);
+        // Handle missing token weights, usually due to missing token prices
+        try {
+          const weight = await getWeight(token);
+          return Math.round(aprs[idx] * weight);
+        } catch (e) {
+          console.log(e);
+          return 0;
+        }
       })
     );
 


### PR DESCRIPTION
When token price was missing APRs were throwing. Changed it to soft fail with a log message.