### PR TITLE
Updated flow and test.

### DIFF
--- a/balancer-js/examples/exitGeneralised.ts
+++ b/balancer-js/examples/exitGeneralised.ts
@@ -122,22 +122,19 @@ const exit = async () => {
   });
 
   // Use SDK to create exit transaction
-  const { expectedAmountsOut, tokensOut } =
-    await balancer.pools.generalisedExit(
+  const { estimatedAmountsOut, tokensOut, needsUnwrap } =
+    await balancer.pools.getExitInfo(
       testPool.id,
       amount,
       signerAddress,
-      slippage,
-      signer,
-      SimulationType.VaultModel,
-      undefined
+      signer
     );
 
   // User reviews expectedAmountOut
-  console.log(' -- Simulating using Vault Model -- ');
+  console.log(' -- getExitInfo() -- ');
   console.table({
     tokensOut: truncateAddresses([testPool.address, ...tokensOut]),
-    expectedAmountsOut: ['0', ...expectedAmountsOut],
+    estimatedAmountsOut: ['0', ...estimatedAmountsOut],
   });
 
   // User approves relayer
@@ -160,6 +157,7 @@ const exit = async () => {
     slippage,
     signer,
     SimulationType.Static,
+    needsUnwrap,
     relayerAuth
   );
 

--- a/balancer-js/src/modules/exits/exits.module.integration.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration.spec.ts
@@ -136,20 +136,18 @@ const testFlow = async (
 
   const signerAddress = await signer.getAddress();
 
-  const query = await pools.generalisedExit(
+  const exitInfo = await pools.getExitInfo(
     pool.id,
     amount,
     signerAddress,
-    slippage,
-    signer,
-    SimulationType.VaultModel
+    signer
   );
 
   // User reviews expectedAmountOut
   console.log(' -- Simulating using Vault Model -- ');
   console.table({
-    tokensOut: truncateAddresses([pool.address, ...query.tokensOut]),
-    expectedAmountsOut: ['0', ...query.expectedAmountsOut],
+    tokensOut: truncateAddresses([pool.address, ...exitInfo.tokensOut]),
+    expectedAmountsOut: ['0', ...exitInfo.estimatedAmountsOut],
   });
 
   const authorisation = await Relayer.signRelayerApproval(
@@ -167,6 +165,7 @@ const testFlow = async (
       slippage,
       signer,
       SimulationType.Static,
+      exitInfo.needsUnwrap,
       authorisation
     );
 

--- a/balancer-js/src/modules/exits/exits.module.ts
+++ b/balancer-js/src/modules/exits/exits.module.ts
@@ -61,8 +61,7 @@ export class Exit {
     poolId: string,
     amountBptIn: string,
     userAddress: string,
-    signer: JsonRpcSigner,
-    authorisation?: string
+    signer: JsonRpcSigner
   ): Promise<{
     tokensOut: string[];
     estimatedAmountsOut: string[];
@@ -85,8 +84,7 @@ export class Exit {
       userAddress,
       signer,
       false,
-      SimulationType.VaultModel,
-      authorisation
+      SimulationType.VaultModel
     );
 
     const priceImpact = await this.calculatePriceImpact(

--- a/balancer-js/src/modules/exits/exits.module.ts
+++ b/balancer-js/src/modules/exits/exits.module.ts
@@ -109,7 +109,7 @@ export class Exit {
     userAddress: string,
     slippage: string,
     signer: JsonRpcSigner,
-    simulationType: SimulationType, // TODO - Narrow this to only static/tenderly as options
+    simulationType: SimulationType.Static | SimulationType.Tenderly,
     unwrapTokens: boolean,
     authorisation?: string
   ): Promise<{
@@ -132,8 +132,6 @@ export class Exit {
     - Return minAmoutsOut, UI would use this to display to user
     - Return updatedCalls, UI would use this to execute tx
     */
-    if (simulationType === SimulationType.VaultModel)
-      throw new Error(`Cant use VaultModel as simulation type in build call`);
 
     const exit = await this.getExit(
       poolId,

--- a/balancer-js/src/modules/exits/exits.module.ts
+++ b/balancer-js/src/modules/exits/exits.module.ts
@@ -87,18 +87,10 @@ export class Exit {
       SimulationType.VaultModel
     );
 
-    const priceImpact = await this.calculatePriceImpact(
-      poolId,
-      this.poolGraph,
-      exit.tokensOut,
-      exit.expectedAmountsOut,
-      amountBptIn
-    );
-
     return {
       tokensOut: exit.tokensOut,
       estimatedAmountsOut: exit.expectedAmountsOut,
-      priceImpact,
+      priceImpact: exit.priceImpact,
       needsUnwrap: exit.unwrap,
     };
   }
@@ -168,21 +160,13 @@ export class Exit {
       minAmountsOutByTokenOut
     );
 
-    const priceImpact = await this.calculatePriceImpact(
-      poolId,
-      this.poolGraph,
-      exit.tokensOut,
-      exit.expectedAmountsOut,
-      amountBptIn
-    );
-
     return {
       to: this.relayer,
       encodedCall,
       tokensOut: exit.tokensOut,
       expectedAmountsOut: exit.expectedAmountsOut,
       minAmountsOut: minAmountsOutByTokenOut,
-      priceImpact,
+      priceImpact: exit.priceImpact,
     };
   }
 
@@ -201,6 +185,7 @@ export class Exit {
     isProportional: boolean;
     expectedAmountsOut: string[];
     expectedAmountsOutByExitPath: string[];
+    priceImpact: string;
   }> {
     // Create nodes and order by breadth first - initially trys with no unwrapping
     const orderedNodes = await this.poolGraph.getGraphNodes(
@@ -287,6 +272,15 @@ export class Exit {
         tokensOutByExitPath,
         expectedAmountsOutByExitPath
       );
+
+      const priceImpact = await this.calculatePriceImpact(
+        poolId,
+        this.poolGraph,
+        tokensOut,
+        expectedAmountsOut,
+        amountBptIn
+      );
+
       return {
         unwrap: doUnwrap,
         tokensOut,
@@ -294,6 +288,7 @@ export class Exit {
         isProportional,
         expectedAmountsOut,
         expectedAmountsOutByExitPath,
+        priceImpact,
       };
     }
   }

--- a/balancer-js/src/modules/exits/exitsProportional.module.integration.spec.ts
+++ b/balancer-js/src/modules/exits/exitsProportional.module.integration.spec.ts
@@ -105,7 +105,7 @@ const testFlow = async (
   pool: { id: string; address: string },
   amount: string,
   authorisation: string | undefined,
-  simulationType = SimulationType.VaultModel
+  simulationType = SimulationType.Static
 ) => {
   const gasLimit = 8e6;
   const slippage = '10'; // 10 bps = 0.1%
@@ -118,6 +118,7 @@ const testFlow = async (
       slippage,
       signer,
       simulationType,
+      false,
       authorisation
     );
 

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -390,12 +390,20 @@ export class Pools implements Findable<PoolWithMethods> {
     );
   }
 
+  /**
+   * Gets info required to build generalised exit transaction
+   *
+   * @param poolId          Pool id
+   * @param amountBptIn     BPT amount in EVM scale
+   * @param userAddress     User address
+   * @param signer          JsonRpcSigner that will sign the staticCall transaction if Static simulation chosen
+   * @returns info required to build a generalised exit transaction including whether tokens need to be unwrapped
+   */
   async getExitInfo(
     poolId: string,
     amountBptIn: string,
     userAddress: string,
-    signer: JsonRpcSigner,
-    authorisation?: string
+    signer: JsonRpcSigner
   ): Promise<{
     tokensOut: string[];
     estimatedAmountsOut: string[];
@@ -406,8 +414,7 @@ export class Pools implements Findable<PoolWithMethods> {
       poolId,
       amountBptIn,
       userAddress,
-      signer,
-      authorisation
+      signer
     );
   }
 

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -357,6 +357,7 @@ export class Pools implements Findable<PoolWithMethods> {
    * @param slippage        Maximum slippage tolerance in bps i.e. 50 = 0.5%.
    * @param signer          JsonRpcSigner that will sign the staticCall transaction if Static simulation chosen
    * @param simulationType  Simulation type (VaultModel, Tenderly or Static)
+   * @param unwrapTokens    Determines if wrapped tokens should be unwrapped
    * @param authorisation   Optional auhtorisation call to be added to the chained transaction
    * @returns transaction data ready to be sent to the network along with tokens, min and expected amounts out.
    */
@@ -367,6 +368,7 @@ export class Pools implements Findable<PoolWithMethods> {
     slippage: string,
     signer: JsonRpcSigner,
     simulationType: SimulationType,
+    unwrapTokens: boolean,
     authorisation?: string
   ): Promise<{
     to: string;
@@ -376,15 +378,36 @@ export class Pools implements Findable<PoolWithMethods> {
     minAmountsOut: string[];
     priceImpact: string;
   }> {
-    return this.exitService.exitPool(
+    return this.exitService.buildExitCall(
       poolId,
       amount,
       userAddress,
       slippage,
       signer,
       simulationType,
-      authorisation,
-      false // This is initially false as the function will auto switch to unwrap method if needed
+      unwrapTokens,
+      authorisation
+    );
+  }
+
+  async getExitInfo(
+    poolId: string,
+    amountBptIn: string,
+    userAddress: string,
+    signer: JsonRpcSigner,
+    authorisation?: string
+  ): Promise<{
+    tokensOut: string[];
+    estimatedAmountsOut: string[];
+    priceImpact: string;
+    needsUnwrap: boolean;
+  }> {
+    return this.exitService.getExitInfo(
+      poolId,
+      amountBptIn,
+      userAddress,
+      signer,
+      authorisation
     );
   }
 

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -356,7 +356,7 @@ export class Pools implements Findable<PoolWithMethods> {
    * @param userAddress     User address
    * @param slippage        Maximum slippage tolerance in bps i.e. 50 = 0.5%.
    * @param signer          JsonRpcSigner that will sign the staticCall transaction if Static simulation chosen
-   * @param simulationType  Simulation type (VaultModel, Tenderly or Static)
+   * @param simulationType  Simulation type (Tenderly or Static) - VaultModel should not be used to build exit transaction
    * @param unwrapTokens    Determines if wrapped tokens should be unwrapped
    * @param authorisation   Optional auhtorisation call to be added to the chained transaction
    * @returns transaction data ready to be sent to the network along with tokens, min and expected amounts out.
@@ -367,7 +367,7 @@ export class Pools implements Findable<PoolWithMethods> {
     userAddress: string,
     slippage: string,
     signer: JsonRpcSigner,
-    simulationType: SimulationType,
+    simulationType: SimulationType.Static | SimulationType.Tenderly,
     unwrapTokens: boolean,
     authorisation?: string
   ): Promise<{


### PR DESCRIPTION
There was an issue with the current flow and unwrapping:
1. With vault model:
  - Initially tries with no unwrap, gets `expectedAmountsOutByExitPath` by using TS maths
  - `expectedAmountsOutByExitPath` is compared to linear main balances and if less unwrap is found
  - Because we use TS maths no errors are thrown and unwrap is discovered
2. With static model:
  - Initially tries with no unwrap, gets `expectedAmountsOutByExitPath` by using static call
  - The static call throws because its not possible to do this exit
  - We can't do rest
This would cause issues on UI.

Here I change it to a new flow.
- `getExitInfo`: 
  - Returns the info UI needs to display to user (based off TS maths) and whether an unwrap is needed
  - returns estimatedOutputs and needsUnwrap
  - No concept of slippage here
  - No calls returned - makes sure its clear this isn't for submitting
- Pass these to `generalisedExit`
  - Does slippage
  - Does static call or Tenderly call only to make sure its as accurate as possible
