### PR TITLE
Generalised Exit - Add ability to exit by selectively unwrapping tokens

### DIFF
--- a/balancer-js/examples/exitGeneralised.ts
+++ b/balancer-js/examples/exitGeneralised.ts
@@ -17,10 +17,10 @@ import { SimulationType } from '../src/modules/simulation/simulation.module';
 
 // Expected frontend (FE) flow:
 // 1. User selects BPT amount to exit a pool
-// 2. FE calls exitGeneralised with simulation type VaultModel
-// 3. SDK calculates expectedAmountsOut that is at least 99% accurate
+// 2. FE calls exitInfo
+// 3. SDK returns expectedAmountsOut that is at least 99% accurate and indicates which tokens should be unwrapped (tokensToUnwrap)
 // 4. User agrees expectedAmountsOut and approves relayer
-// 5. With approvals in place, FE calls exitGeneralised with simulation type Static
+// 5. With approvals in place, FE calls exitGeneralised with simulation type Static and tokensToUnwrap
 // 6. SDK calculates expectedAmountsOut that is 100% accurate
 // 7. SDK returns exitGeneralised transaction data with proper minAmountsOut limits in place
 // 8. User is now able to submit a safe transaction to the blockchain

--- a/balancer-js/examples/exitGeneralised.ts
+++ b/balancer-js/examples/exitGeneralised.ts
@@ -18,11 +18,11 @@ import { SimulationType } from '../src/modules/simulation/simulation.module';
 // Expected frontend (FE) flow:
 // 1. User selects BPT amount to exit a pool
 // 2. FE calls exitInfo
-// 3. SDK returns expectedAmountsOut that is at least 99% accurate and indicates which tokens should be unwrapped (tokensToUnwrap)
-// 4. User agrees expectedAmountsOut and approves relayer
+// 3. SDK returns estimatedAmountsOut that is at least 99% accurate and indicates which tokens should be unwrapped (tokensToUnwrap)
+// 4. User agrees estimatedAmountsOut and approves relayer
 // 5. With approvals in place, FE calls exitGeneralised with simulation type Static and tokensToUnwrap
 // 6. SDK calculates expectedAmountsOut that is 100% accurate
-// 7. SDK returns exitGeneralised transaction data with proper minAmountsOut limits in place
+// 7. SDK returns exitGeneralised transaction data with proper minAmountsOut limits in place (calculated using user defined slippage)
 // 8. User is now able to submit a safe transaction to the blockchain
 
 dotenv.config();

--- a/balancer-js/examples/exitGeneralised.ts
+++ b/balancer-js/examples/exitGeneralised.ts
@@ -8,6 +8,7 @@ import {
   GraphQLArgs,
   Network,
   truncateAddresses,
+  removeItem,
 } from '../src/index';
 import { forkSetup, sendTransactionGetBalances } from '../src/test/lib/utils';
 import { ADDRESSES } from '../src/test/lib/constants';
@@ -133,10 +134,11 @@ const exit = async () => {
 
   // User reviews expectedAmountOut
   console.log(' -- getExitInfo() -- ');
+  console.log(tokensToUnwrap.toString());
   console.table({
-    tokensOut: truncateAddresses([testPool.address, ...tokensOut]),
-    estimatedAmountsOut: ['0', ...estimatedAmountsOut],
-    tokensToUnwrap,
+    tokensOut: truncateAddresses(tokensOut),
+    estimatedAmountsOut: estimatedAmountsOut,
+    unwrap: tokensOut.map((t) => tokensToUnwrap.includes(t)),
   });
 
   // User approves relayer
@@ -174,11 +176,12 @@ const exit = async () => {
 
   console.log(' -- Simulating using Static Call -- ');
   console.log('Price impact: ', formatFixed(query.priceImpact, 18));
+  console.log(`Amount Pool Token In: ${balanceDeltas[0].toString()}`);
   console.table({
-    tokensOut: truncateAddresses([testPool.address, ...query.tokensOut]),
-    minAmountsOut: ['0', ...query.minAmountsOut],
-    expectedAmountsOut: ['0', ...query.expectedAmountsOut],
-    balanceDeltas: balanceDeltas.map((b) => b.toString()),
+    tokensOut: truncateAddresses(query.tokensOut),
+    minAmountsOut: query.minAmountsOut,
+    expectedAmountsOut: query.expectedAmountsOut,
+    balanceDeltas: removeItem(balanceDeltas, 0).map((b) => b.toString()),
   });
 };
 

--- a/balancer-js/examples/exitGeneralised.ts
+++ b/balancer-js/examples/exitGeneralised.ts
@@ -123,7 +123,7 @@ const exit = async () => {
   });
 
   // Use SDK to create exit transaction
-  const { estimatedAmountsOut, tokensOut, needsUnwrap } =
+  const { estimatedAmountsOut, tokensOut, tokensToUnwrap } =
     await balancer.pools.getExitInfo(
       testPool.id,
       amount,
@@ -136,6 +136,7 @@ const exit = async () => {
   console.table({
     tokensOut: truncateAddresses([testPool.address, ...tokensOut]),
     estimatedAmountsOut: ['0', ...estimatedAmountsOut],
+    tokensToUnwrap,
   });
 
   // User approves relayer
@@ -159,7 +160,7 @@ const exit = async () => {
     signer,
     SimulationType.Static,
     relayerAuth,
-    needsUnwrap
+    tokensToUnwrap
   );
 
   // Submit transaction and check balance deltas to confirm success

--- a/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
@@ -82,6 +82,7 @@ describe('generalised exit execution', async function () {
       });
     });
   });
+
   context('GearboxLinear - bbgusd', async () => {
     const network = Network.MAINNET;
     const blockNo = 17263241;
@@ -98,6 +99,74 @@ describe('generalised exit execution', async function () {
     const amountRatio = 100000;
     // Amount greater than the underlying main token balance, which will cause the exit to be unwrapped
     const unwrapExitAmount = parseFixed('1000000', pool.decimals);
+    // Amount smaller than the underlying main token balance, which will cause the exit to be done directly
+    const mainExitAmount = unwrapExitAmount.div(amountRatio);
+
+    context('exit by unwrapping tokens', async () => {
+      it('should exit via unwrapping', async () => {
+        const { expectedAmountsOut, gasUsed } = await testFlow(
+          pool,
+          slippage,
+          unwrapExitAmount.toString(),
+          true,
+          network,
+          blockNo,
+          poolAddresses
+        );
+        unwrappingTokensAmountsOut = expectedAmountsOut;
+        unwrappingTokensGasUsed = gasUsed;
+      });
+    });
+
+    context('exit to main tokens directly', async () => {
+      it('should exit to main tokens directly', async () => {
+        const { expectedAmountsOut, gasUsed } = await testFlow(
+          pool,
+          slippage,
+          mainExitAmount.toString(),
+          false,
+          network,
+          blockNo,
+          poolAddresses
+        );
+        mainTokensAmountsOut = expectedAmountsOut;
+        mainTokensGasUsed = gasUsed;
+      });
+    });
+
+    context('exit by unwrapping vs exit to main tokens', async () => {
+      it('should return similar amounts (proportional to the input)', async () => {
+        mainTokensAmountsOut.forEach((amount, i) => {
+          const unwrappedAmount = BigNumber.from(
+            unwrappingTokensAmountsOut[i]
+          ).div(amountRatio);
+          expect(
+            accuracy(unwrappedAmount, BigNumber.from(amount))
+          ).to.be.closeTo(1, 1e-4); // inaccuracy should not be over 1 bps
+        });
+      });
+      it('should spend more gas when unwrapping tokens', async () => {
+        expect(unwrappingTokensGasUsed.gt(mainTokensGasUsed)).to.be.true;
+      });
+    });
+  });
+
+  context('AaveLinear - bbausd', async () => {
+    const network = Network.MAINNET;
+    const blockNo = 17273179;
+    const pool = ADDRESSES[network].bbausd2;
+    const slippage = '10'; // 10 bps = 0.1%
+    let unwrappingTokensAmountsOut: string[];
+    let unwrappingTokensGasUsed: BigNumber;
+    let mainTokensAmountsOut: string[];
+    let mainTokensGasUsed: BigNumber;
+    const poolAddresses = Object.values(ADDRESSES[network]).map(
+      (address) => address.address
+    );
+
+    const amountRatio = 1000;
+    // Amount greater than the underlying main token balance, which will cause the exit to be unwrapped
+    const unwrapExitAmount = parseFixed('3000000', pool.decimals);
     // Amount smaller than the underlying main token balance, which will cause the exit to be done directly
     const mainExitAmount = unwrapExitAmount.div(amountRatio);
 

--- a/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
@@ -40,7 +40,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           unwrapExitAmount.toString(),
-          true,
+          [ADDRESSES[network].USDC.address],
           network,
           blockNo,
           poolAddresses
@@ -56,7 +56,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           mainExitAmount.toString(),
-          false,
+          [],
           network,
           blockNo,
           poolAddresses
@@ -108,7 +108,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           unwrapExitAmount.toString(),
-          true,
+          [ADDRESSES[network].DAI.address, ADDRESSES[network].USDC.address],
           network,
           blockNo,
           poolAddresses
@@ -124,7 +124,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           mainExitAmount.toString(),
-          false,
+          [],
           network,
           blockNo,
           poolAddresses
@@ -153,7 +153,7 @@ describe('generalised exit execution', async function () {
 
   context('AaveLinear - bbausd', async () => {
     const network = Network.MAINNET;
-    const blockNo = 17273179;
+    const blockNo = 17263241;
     const pool = ADDRESSES[network].bbausd2;
     const slippage = '10'; // 10 bps = 0.1%
     let unwrappingTokensAmountsOut: string[];
@@ -176,7 +176,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           unwrapExitAmount.toString(),
-          true,
+          [ADDRESSES[network].DAI.address],
           network,
           blockNo,
           poolAddresses
@@ -192,7 +192,7 @@ describe('generalised exit execution', async function () {
           pool,
           slippage,
           mainExitAmount.toString(),
-          false,
+          [],
           network,
           blockNo,
           poolAddresses
@@ -210,7 +210,7 @@ describe('generalised exit execution', async function () {
           ).div(amountRatio);
           expect(
             accuracy(unwrappedAmount, BigNumber.from(amount))
-          ).to.be.closeTo(1, 1e-4); // inaccuracy should not be over 1 bps
+          ).to.be.closeTo(1, 1e-3); // inaccuracy should not be over 10 bps
         });
       });
       it('should spend more gas when unwrapping tokens', async () => {

--- a/balancer-js/src/modules/exits/exits.module.integration.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration.spec.ts
@@ -43,7 +43,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -66,7 +66,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -89,7 +89,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -114,7 +114,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -137,7 +137,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -162,7 +162,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -186,7 +186,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -209,7 +209,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses
@@ -234,7 +234,7 @@ describe('generalised exit execution', async function () {
         pool,
         slippage,
         amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses

--- a/balancer-js/src/modules/exits/exitsProportional.module.integration.spec.ts
+++ b/balancer-js/src/modules/exits/exitsProportional.module.integration.spec.ts
@@ -29,7 +29,7 @@ const runTests = async (tests: Test[]) => {
         test.pool,
         slippage,
         test.amount,
-        false,
+        [],
         network,
         blockNumber,
         poolAddresses

--- a/balancer-js/src/modules/exits/testHelper.ts
+++ b/balancer-js/src/modules/exits/testHelper.ts
@@ -44,7 +44,7 @@ export const testFlow = async (
   pool: Pool,
   slippage: string,
   exitAmount: string,
-  expectUnwrap: boolean,
+  expectToUnwrap: string[],
   network: Network,
   blockNumber: number,
   poolAddressesToConsider: string[]
@@ -77,11 +77,11 @@ export const testFlow = async (
     balanceDeltas: tokensOutDeltas.map((b) => b.toString()),
   });
   console.log('Gas used', txResult.gasUsed.toString());
-  console.log(`Should unwrap: `, exitInfo.needsUnwrap);
+  console.log(`Tokens to unwrap: `, exitInfo.tokensToUnwrap);
 
   expect(txResult.transactionReceipt.status).to.eq(1);
   expect(txResult.balanceDeltas[0].toString()).to.eq(exitAmount.toString());
-  expect(exitInfo.needsUnwrap).to.eq(expectUnwrap);
+  expect(exitInfo.tokensToUnwrap).to.deep.eq(expectToUnwrap);
   tokensOutDeltas.forEach((b, i) => {
     const minOut = BigNumber.from(exitOutput.minAmountsOut[i]);
     expect(b.gte(minOut)).to.be.true;
@@ -137,7 +137,7 @@ async function userFlow(
     signer,
     SimulationType.Static,
     authorisation,
-    exitInfo.needsUnwrap
+    exitInfo.tokensToUnwrap
   );
   // 3. Sends tx
   const txResult = await sendTransactionGetBalances(

--- a/balancer-js/src/modules/joins/joins.module.ts
+++ b/balancer-js/src/modules/joins/joins.module.ts
@@ -67,11 +67,7 @@ export class Join {
       throw new BalancerError(BalancerErrorCode.INPUT_LENGTH_MISMATCH);
 
     // Create nodes for each pool/token interaction and order by breadth first
-    const orderedNodes = await this.poolGraph.getGraphNodes(
-      true,
-      poolId,
-      false
-    );
+    const orderedNodes = await this.poolGraph.getGraphNodes(true, poolId, []);
 
     const joinPaths = Join.getJoinPaths(orderedNodes, tokensIn, amountsIn);
 

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -358,7 +358,7 @@ export class Pools implements Findable<PoolWithMethods> {
    * @param signer          JsonRpcSigner that will sign the staticCall transaction if Static simulation chosen
    * @param simulationType  Simulation type (Tenderly or Static) - VaultModel should not be used to build exit transaction
    * @param authorisation   Optional auhtorisation call to be added to the chained transaction
-   * @param unwrapTokens    Determines if wrapped tokens should be unwrapped. Default = false
+   * @param tokensToUnwrap  List all tokens that requires exit by unwrapping - info provided by getExitInfo
    * @returns transaction data ready to be sent to the network along with tokens, min and expected amounts out.
    */
   async generalisedExit(
@@ -369,7 +369,7 @@ export class Pools implements Findable<PoolWithMethods> {
     signer: JsonRpcSigner,
     simulationType: SimulationType.Static | SimulationType.Tenderly,
     authorisation?: string,
-    unwrapTokens = false
+    tokensToUnwrap?: string[]
   ): Promise<GeneralisedExitOutput> {
     return this.exitService.buildExitCall(
       poolId,
@@ -379,7 +379,7 @@ export class Pools implements Findable<PoolWithMethods> {
       signer,
       simulationType,
       authorisation,
-      unwrapTokens
+      tokensToUnwrap
     );
   }
 


### PR DESCRIPTION
With the previous solution, generalisedExit was able to only exit with the following options:
1. exit directly to all underlying main tokens
2. exit by unwrapping all underlying wrapped tokens

This PR updates option 2 to:
2. exit by unwrapping only selected underlying wrapped tokens

See [this asana task](https://app.asana.com/0/1201380039585484/1204564187636490/f) for more details on which problem this solves.