### PR TITLE
Add support to join/exit ComposableStable V4 Pools

### DIFF
--- a/balancer-js/src/modules/exits/testHelper.ts
+++ b/balancer-js/src/modules/exits/testHelper.ts
@@ -15,24 +15,12 @@ import {
   accuracy,
   forkSetup,
   sendTransactionGetBalances,
+  FORK_NODES,
+  RPC_URLS,
 } from '@/test/lib/utils';
 import { Relayer } from '@/modules/relayer/relayer.module';
 import { SimulationType } from '../simulation/simulation.module';
 import { GeneralisedExitOutput, ExitInfo } from '../exits/exits.module';
-
-const RPC_URLS: Record<number, string> = {
-  [Network.MAINNET]: `http://127.0.0.1:8545`,
-  [Network.GOERLI]: `http://127.0.0.1:8000`,
-  [Network.POLYGON]: `http://127.0.0.1:8137`,
-  [Network.ARBITRUM]: `http://127.0.0.1:8161`,
-};
-
-const FORK_NODES: Record<number, string> = {
-  [Network.MAINNET]: `${process.env.ALCHEMY_URL}`,
-  [Network.GOERLI]: `${process.env.ALCHEMY_URL_GOERLI}`,
-  [Network.POLYGON]: `${process.env.ALCHEMY_URL_POLYGON}`,
-  [Network.ARBITRUM]: `${process.env.ALCHEMY_URL_ARBITRUM}`,
-};
 
 export interface Pool {
   id: string;

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV2.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV2.concern.integration.spec.ts
@@ -30,7 +30,7 @@ const blockNumber = 40818844;
 let pool: PoolWithMethods;
 
 describe('ComposableStableV2 Exits', () => {
-  // We have to rest the fork between each test as pool value changes after tx is submitted
+  // We have to reset the fork between each test as pool value changes after tx is submitted
   beforeEach(async () => {
     // Setup forked network, set initial token balances and allowances
     await forkSetup(

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV3.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV3.concern.integration.spec.ts
@@ -1,110 +1,64 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/composableStable/exitV3.concern.integration.spec.ts
 import dotenv from 'dotenv';
-import { expect } from 'chai';
-import { ethers } from 'hardhat';
-import { BigNumber, parseFixed } from '@ethersproject/bignumber';
-import { insert, Network, PoolWithMethods, removeItem } from '@/.';
-import { subSlippage, addSlippage } from '@/lib/utils/slippageHelper';
+import { parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
 import {
-  forkSetup,
-  TestPoolHelper,
-  sendTransactionGetBalances,
-} from '@/test/lib/utils';
+  BALANCER_NETWORK_CONFIG,
+  getPoolAddress,
+  Network,
+  Pools,
+  PoolWithMethods,
+  removeItem,
+} from '@/.';
+import { forkSetup, getPoolFromFile, updateFromChain } from '@/test/lib/utils';
+import { testExactBptIn, testExactTokensOut } from '@/test/lib/exitHelper';
 
 dotenv.config();
 
 const network = Network.MAINNET;
 const { ALCHEMY_URL: jsonRpcUrl } = process.env;
 const rpcUrl = 'http://127.0.0.1:8545';
-const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
+const provider = new JsonRpcProvider(rpcUrl, network);
 const signer = provider.getSigner();
 const blockNumber = 16649181;
 
 // wstETH-rETH-sfrxETH-BPT
 const testPoolId =
   '0x5aee1e99fe86960377de9f88689616916d5dcabe000000000000000000000467';
-
-let signerAddress: string;
 let pool: PoolWithMethods;
 
-// TODO Add these tests back once Protocol Fees are handled - check V1 and V2 tests to be used as reference
-describe.skip('ComposableStableV3 Exits', () => {
-  // We have to rest the fork between each test as pool value changes after tx is submitted
+describe('ComposableStableV3 Exits', () => {
   beforeEach(async () => {
-    signerAddress = await signer.getAddress();
-
-    const testPool = new TestPoolHelper(
-      testPoolId,
-      network,
-      rpcUrl,
-      blockNumber
-    );
-
-    // Gets initial pool info from Subgraph
-    pool = await testPool.getPool();
-
     // Setup forked network, set initial token balances and allowances
     await forkSetup(
       signer,
-      pool.tokensList,
-      Array(pool.tokensList.length).fill(0),
-      Array(pool.tokensList.length).fill(parseFixed('10', 18).toString()),
+      [getPoolAddress(testPoolId)],
+      [0],
+      [parseFixed('10000', 18).toString()],
       jsonRpcUrl as string,
       blockNumber
     );
 
+    let testPool = await getPoolFromFile(testPoolId, network);
     // Updatate pool info with onchain state from fork block no
-    pool = await testPool.getPool();
-  });
+    testPool = await updateFromChain(testPool, network, provider);
 
+    pool = Pools.wrap(testPool, BALANCER_NETWORK_CONFIG[network]);
+  });
   context('exitExactBPTIn', async () => {
     it('single token max out', async () => {
       const bptIn = parseFixed('0.1', 18).toString();
-      const slippage = '10';
-      const { to, data, minAmountsOut, expectedAmountsOut } =
-        pool.buildExitExactBPTIn(
-          signerAddress,
-          bptIn,
-          slippage,
-          false,
-          pool.tokensList[1]
-        );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          pool.tokensList,
-          signer,
-          signerAddress,
-          to,
-          data
-        );
-      expect(transactionReceipt.status).to.eq(1);
-      const expectedDeltas = insert(expectedAmountsOut, pool.bptIndex, bptIn);
-      expect(expectedDeltas).to.deep.eq(balanceDeltas.map((a) => a.toString()));
-      const expectedMins = expectedAmountsOut.map((a) =>
-        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
-      );
-      expect(expectedMins).to.deep.eq(minAmountsOut);
+      const tokenOut = pool.tokensList[0];
+      await testExactBptIn(pool, signer, bptIn, tokenOut);
+    });
+    it('single token max out, token out after BPT index', async () => {
+      const bptIn = parseFixed('0.1', 18).toString();
+      const tokenOut = pool.tokensList[2];
+      await testExactBptIn(pool, signer, bptIn, tokenOut);
     });
     it('proportional exit', async () => {
-      const bptIn = parseFixed('0.01', 18).toString();
-      const slippage = '10';
-      const { to, data, minAmountsOut, expectedAmountsOut } =
-        pool.buildExitExactBPTIn(signerAddress, bptIn, slippage, false);
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          pool.tokensList,
-          signer,
-          signerAddress,
-          to,
-          data
-        );
-      expect(transactionReceipt.status).to.eq(1);
-      const expectedDeltas = insert(expectedAmountsOut, pool.bptIndex, bptIn);
-      expect(expectedDeltas).to.deep.eq(balanceDeltas.map((a) => a.toString()));
-      const expectedMins = expectedAmountsOut.map((a) =>
-        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
-      );
-      expect(expectedMins).to.deep.eq(minAmountsOut);
+      const bptIn = parseFixed('0.1', 18).toString();
+      await testExactBptIn(pool, signer, bptIn);
     });
   });
 
@@ -112,61 +66,21 @@ describe.skip('ComposableStableV3 Exits', () => {
     it('all tokens with value', async () => {
       const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
       const amountsOut = tokensOut.map((_, i) =>
-        parseFixed((i * 1).toString(), 18).toString()
+        parseFixed(((i + 1) * 0.1).toString(), 18).toString()
       );
-      const slippage = '7';
-      const { to, data, maxBPTIn, expectedBPTIn } =
-        pool.buildExitExactTokensOut(
-          signerAddress,
-          tokensOut,
-          amountsOut,
-          slippage
-        );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          pool.tokensList,
-          signer,
-          signerAddress,
-          to,
-          data
-        );
-      expect(transactionReceipt.status).to.eq(1);
-      const expectedDeltas = insert(amountsOut, pool.bptIndex, expectedBPTIn);
-      expect(expectedDeltas).to.deep.eq(balanceDeltas.map((a) => a.toString()));
-      const expectedMaxBpt = addSlippage(
-        BigNumber.from(expectedBPTIn),
-        BigNumber.from(slippage)
-      ).toString();
-      expect(expectedMaxBpt).to.deep.eq(maxBPTIn);
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
     });
     it('single token with value', async () => {
       const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
       const amountsOut = Array(tokensOut.length).fill('0');
-      amountsOut[0] = parseFixed('2', 18).toString();
-      const slippage = '7';
-      const { to, data, maxBPTIn, expectedBPTIn } =
-        pool.buildExitExactTokensOut(
-          signerAddress,
-          tokensOut,
-          amountsOut,
-          slippage
-        );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          pool.tokensList,
-          signer,
-          signerAddress,
-          to,
-          data
-        );
-      expect(transactionReceipt.status).to.eq(1);
-      const expectedDeltas = insert(amountsOut, pool.bptIndex, expectedBPTIn);
-      expect(expectedDeltas).to.deep.eq(balanceDeltas.map((a) => a.toString()));
-      const expectedMaxBpt = addSlippage(
-        BigNumber.from(expectedBPTIn),
-        BigNumber.from(slippage)
-      ).toString();
-      expect(expectedMaxBpt).to.deep.eq(maxBPTIn);
+      amountsOut[0] = parseFixed('0.1', 18).toString();
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
+    });
+    it('single token with value, token out after BPT index', async () => {
+      const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsOut = Array(tokensOut.length).fill('0');
+      amountsOut[2] = parseFixed('0.1', 18).toString();
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
     });
   });
 });

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV4.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV4.concern.integration.spec.ts
@@ -1,0 +1,86 @@
+// yarn test:only ./src/modules/pools/pool-types/concerns/composableStable/exitV4.concern.integration.spec.ts
+import dotenv from 'dotenv';
+import { parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import {
+  BALANCER_NETWORK_CONFIG,
+  getPoolAddress,
+  Network,
+  Pools,
+  PoolWithMethods,
+  removeItem,
+} from '@/.';
+import { forkSetup, getPoolFromFile, updateFromChain } from '@/test/lib/utils';
+import { testExactBptIn, testExactTokensOut } from '@/test/lib/exitHelper';
+
+dotenv.config();
+
+const network = Network.MAINNET;
+const { ALCHEMY_URL: jsonRpcUrl } = process.env;
+const rpcUrl = 'http://127.0.0.1:8545';
+const provider = new JsonRpcProvider(rpcUrl, network);
+const signer = provider.getSigner();
+const blockNumber = 17280000;
+
+// wstETH-rETH-sfrxETH-BPT
+const testPoolId =
+  '0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d';
+let pool: PoolWithMethods;
+
+describe('ComposableStableV4 Exits', () => {
+  beforeEach(async () => {
+    // Setup forked network, set initial token balances and allowances
+    await forkSetup(
+      signer,
+      [getPoolAddress(testPoolId)],
+      [0],
+      [parseFixed('10000', 18).toString()],
+      jsonRpcUrl as string,
+      blockNumber
+    );
+
+    let testPool = await getPoolFromFile(testPoolId, network);
+    // Updatate pool info with onchain state from fork block no
+    testPool = await updateFromChain(testPool, network, provider);
+
+    pool = Pools.wrap(testPool, BALANCER_NETWORK_CONFIG[network]);
+  });
+  context('exitExactBPTIn', async () => {
+    it('single token max out', async () => {
+      const bptIn = parseFixed('0.1', 18).toString();
+      const tokenOut = pool.tokensList[0];
+      await testExactBptIn(pool, signer, bptIn, tokenOut);
+    });
+    it('single token max out, token out after BPT index', async () => {
+      const bptIn = parseFixed('0.1', 18).toString();
+      const tokenOut = pool.tokensList[2];
+      await testExactBptIn(pool, signer, bptIn, tokenOut);
+    });
+    it('proportional exit', async () => {
+      const bptIn = parseFixed('0.1', 18).toString();
+      await testExactBptIn(pool, signer, bptIn);
+    });
+  });
+
+  context('exitExactTokensOut', async () => {
+    it('all tokens with value', async () => {
+      const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsOut = tokensOut.map((_, i) =>
+        parseFixed(((i + 1) * 0.1).toString(), 18).toString()
+      );
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
+    });
+    it('single token with value', async () => {
+      const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsOut = Array(tokensOut.length).fill('0');
+      amountsOut[0] = parseFixed('0.1', 18).toString();
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
+    });
+    it('single token with value, token out after BPT index', async () => {
+      const tokensOut = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsOut = Array(tokensOut.length).fill('0');
+      amountsOut[1] = parseFixed('0.1', 18).toString();
+      await testExactTokensOut(pool, signer, tokensOut, amountsOut);
+    });
+  });
+});

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.integration.spec.ts
@@ -1,7 +1,6 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/composableStable/join.concern.integration.spec.ts
-import dotenv from 'dotenv';
-import { ethers } from 'hardhat';
 import { parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 
 import {
   removeItem,
@@ -10,7 +9,12 @@ import {
   replace,
   BALANCER_NETWORK_CONFIG,
 } from '@/.';
-import { forkSetup, TestPoolHelper } from '@/test/lib/utils';
+import {
+  FORK_NODES,
+  forkSetup,
+  RPC_URLS,
+  TestPoolHelper,
+} from '@/test/lib/utils';
 import {
   testExactTokensIn,
   testAttributes,
@@ -18,36 +22,41 @@ import {
 } from '@/test/lib/joinHelper';
 import { AddressZero } from '@ethersproject/constants';
 
-dotenv.config();
-
-const network = Network.POLYGON;
-const { ALCHEMY_URL_POLYGON: jsonRpcUrl } = process.env;
-const rpcUrl = 'http://127.0.0.1:8137';
-const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
-const signer = provider.getSigner();
-const blockNumber = 42462957;
-const testPoolId =
-  '0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda400000000000000000000088f';
-
 describe('ComposableStable Pool - Join Functions', async () => {
   let signerAddress: string;
   let pool: PoolWithMethods;
   let testPoolHelper: TestPoolHelper;
-  before(async () => {
-    signerAddress = await signer.getAddress();
+  let network: Network;
+  let jsonRpcUrl: string;
+  let rpcUrl: string;
+  let provider: JsonRpcProvider;
+  let signer: JsonRpcSigner;
+  let blockNumber: number;
+  let testPoolId: string;
 
-    testPoolHelper = new TestPoolHelper(
-      testPoolId,
-      network,
-      rpcUrl,
-      blockNumber
-    );
+  context('Integration Tests - Join V1', async () => {
+    before(async () => {
+      network = Network.POLYGON;
+      rpcUrl = RPC_URLS[network];
+      provider = new JsonRpcProvider(rpcUrl, network);
+      signer = provider.getSigner();
+      signerAddress = await signer.getAddress();
+      jsonRpcUrl = FORK_NODES[network];
+      blockNumber = 42462957;
+      testPoolId =
+        '0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda400000000000000000000088f';
 
-    // Gets initial pool info from Subgraph
-    pool = await testPoolHelper.getPool();
-  });
+      testPoolHelper = new TestPoolHelper(
+        testPoolId,
+        network,
+        rpcUrl,
+        blockNumber
+      );
 
-  context('Integration Tests', async () => {
+      // Gets initial pool info from Subgraph
+      pool = await testPoolHelper.getPool();
+    });
+
     // We have to rest the fork between each test as pool value changes after tx is submitted
     beforeEach(async () => {
       // Setup forked network, set initial token balances and allowances
@@ -56,7 +65,7 @@ describe('ComposableStable Pool - Join Functions', async () => {
         pool.tokensList,
         [0, 3, 0],
         Array(pool.tokensList.length).fill(parseFixed('100000', 18).toString()),
-        jsonRpcUrl as string,
+        jsonRpcUrl,
         blockNumber // holds the same state as the static repository
       );
 
@@ -95,11 +104,67 @@ describe('ComposableStable Pool - Join Functions', async () => {
     });
   });
 
+  context('Integration Tests - Join V4', async () => {
+    beforeEach(async () => {
+      network = Network.MAINNET;
+      rpcUrl = RPC_URLS[network];
+      provider = new JsonRpcProvider(rpcUrl, network);
+      signer = provider.getSigner();
+      signerAddress = await signer.getAddress();
+      jsonRpcUrl = FORK_NODES[network];
+      blockNumber = 17280000;
+      testPoolId =
+        '0xd61e198e139369a40818fe05f5d5e6e045cd6eaf000000000000000000000540';
+
+      testPoolHelper = new TestPoolHelper(
+        testPoolId,
+        network,
+        rpcUrl,
+        blockNumber
+      );
+
+      // Gets initial pool info from Subgraph
+      pool = await testPoolHelper.getPool();
+    });
+
+    // We have to rest the fork between each test as pool value changes after tx is submitted
+    beforeEach(async () => {
+      // Setup forked network, set initial token balances and allowances
+      await forkSetup(
+        signer,
+        pool.tokensList,
+        [0, 5, 0],
+        Array(pool.tokensList.length).fill(parseFixed('10', 18).toString()),
+        jsonRpcUrl,
+        blockNumber, // holds the same state as the static repository
+        [false, true, false]
+      );
+
+      // Updatate pool info with onchain state from fork block no
+      pool = await testPoolHelper.getPool();
+    });
+
+    it('should join - all tokens have value', async () => {
+      const tokensIn = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsIn = tokensIn.map((_, i) =>
+        parseFixed(((i + 1) * 0.1).toString(), 18).toString()
+      );
+      await testExactTokensIn(pool, signer, signerAddress, tokensIn, amountsIn);
+    });
+
+    it('should join - single token has value', async () => {
+      const tokensIn = removeItem(pool.tokensList, pool.bptIndex);
+      const amountsIn = Array(tokensIn.length).fill('0');
+      amountsIn[0] = parseFixed('0.202', 18).toString();
+      await testExactTokensIn(pool, signer, signerAddress, tokensIn, amountsIn);
+    });
+  });
+
   context('Unit Tests', () => {
     it('should return correct attributes for joining', () => {
       const tokensIn = removeItem(pool.tokensList, pool.bptIndex);
       const amountsIn = tokensIn.map((_, i) =>
-        parseFixed(((i + 1) * 100).toString(), 18).toString()
+        parseFixed(((i + 1) * 0.1).toString(), 18).toString()
       );
       testAttributes(pool, testPoolId, signerAddress, tokensIn, amountsIn);
     });
@@ -107,7 +172,7 @@ describe('ComposableStable Pool - Join Functions', async () => {
     it('should automatically sort tokens/amounts in correct order', () => {
       const tokensIn = removeItem(pool.tokensList, pool.bptIndex);
       const amountsIn = tokensIn.map((_, i) =>
-        parseFixed(((i + 1) * 100).toString(), 18).toString()
+        parseFixed(((i + 1) * 0.1).toString(), 18).toString()
       );
       testSortingInputs(pool, signerAddress, tokensIn, amountsIn);
     });

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/join.concern.ts
@@ -106,11 +106,12 @@ export class ComposableStablePoolJoin implements JoinConcern {
      * V1: Does not have proportional exits.
      * V2: Reintroduced proportional exits. Has vulnerability.
      * V3: Fixed vulnerability. Functionally the same as V2.
+     * V4: Update to use new create method with new salt parameter
      */
-    if (pool.poolTypeVersion < 4)
+    if (pool.poolTypeVersion <= 4)
       return this.sortV1(wrappedNativeAsset, tokensIn, amountsIn, pool);
     // Not release yet and needs tests to confirm
-    // else if (values.pool.poolTypeVersion === 4)
+    // else if (values.pool.poolTypeVersion === 5)
     //   sortedValues = this.sortV4(
     //     values.tokensIn,
     //     values.amountsIn,

--- a/balancer-js/src/test/fixtures/pools-mainnet.json
+++ b/balancer-js/src/test/fixtures/pools-mainnet.json
@@ -8058,6 +8058,106 @@
         "strategyType": 1,
         "swapsCount": "723",
         "holdersCount": "4"
+      },
+      {
+        "id": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d",
+        "name": "Balancer UZD/bb-a-USD stableswap",
+        "symbol": "B-S-UZD-BB-A-USD",
+        "address": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983",
+        "poolType": "ComposableStable",
+        "poolTypeVersion": 4,
+        "swapFee": "0.0004",
+        "swapEnabled": true,
+        "protocolYieldFeeCache": "0.5",
+        "protocolSwapFeeCache": "0.5",
+        "amp": "500",
+        "owner": "0xba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1b",
+        "factory": "0xfada0f4547ab2de89d1304a668c39b3e09aa7c76",
+        "tokensList": [
+          "0xb40b6608b2743e691c9b54ddbdee7bf03cd79f1c",
+          "0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983",
+          "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016"
+        ],
+        "tokens": [
+          {
+            "id": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d-0xb40b6608b2743e691c9b54ddbdee7bf03cd79f1c",
+            "symbol": "UZD",
+            "name": "UZD Zunami Stable",
+            "decimals": 18,
+            "address": "0xb40b6608b2743e691c9b54ddbdee7bf03cd79f1c",
+            "balance": "5000",
+            "managedBalance": "0",
+            "weight": null,
+            "priceRate": "1",
+            "token": {
+              "latestUSDPrice": null,
+              "pool": null
+            },
+            "isExemptFromYieldProtocolFee": false
+          },
+          {
+            "id": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d-0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983",
+            "symbol": "B-S-UZD-BB-A-USD",
+            "name": "Balancer UZD/bb-a-USD stableswap",
+            "decimals": 18,
+            "address": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983",
+            "balance": "2596148429257413.218796159909145654",
+            "managedBalance": "0",
+            "weight": null,
+            "priceRate": "1",
+            "token": {
+              "latestUSDPrice": "0.4999798622425397962243462434197151",
+              "pool": {
+                "id": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d",
+                "address": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983",
+                "totalShares": "10000.595469088255464394"
+              }
+            },
+            "isExemptFromYieldProtocolFee": false
+          },
+          {
+            "id": "0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d-0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+            "symbol": "bb-a-USD",
+            "name": "Balancer Aave v3 Boosted StablePool",
+            "decimals": 18,
+            "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+            "balance": "5000",
+            "managedBalance": "0",
+            "weight": null,
+            "priceRate": "1.000119093824728186",
+            "token": {
+              "latestUSDPrice": "1.000034802450382120947007057396189",
+              "pool": {
+                "id": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502",
+                "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+                "totalShares": "21811046.145758434854302198"
+              }
+            },
+            "isExemptFromYieldProtocolFee": true
+          }
+        ],
+        "totalLiquidity": "5000.09634497811362010324384540818",
+        "totalShares": "10000.595469088255464394",
+        "totalSwapFee": "0",
+        "totalSwapVolume": "0",
+        "priceRateProviders": [
+          {
+            "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+            "token": {
+              "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016"
+            }
+          }
+        ],
+        "createTime": 1683442295,
+        "mainIndex": null,
+        "wrappedIndex": null,
+        "totalWeight": "0",
+        "lowerTarget": null,
+        "upperTarget": null,
+        "isInRecoveryMode": null,
+        "strategyType": 0,
+        "swapsCount": "0",
+        "holdersCount": "3"
       }
     ]
   }

--- a/balancer-js/src/test/lib/mainnetPools.ts
+++ b/balancer-js/src/test/lib/mainnetPools.ts
@@ -61,6 +61,16 @@ export const B_50auraBAL_50wstETH = factories.subgraphPoolBase.build({
   ],
 });
 
+export const wstETH_rETH_sfrxETH = factories.subgraphPoolBase.build({
+  id: '0x5aee1e99fe86960377de9f88689616916d5dcabe000000000000000000000467',
+  address: '0x5aee1e99fe86960377de9f88689616916d5dcabe'.toLowerCase(),
+  tokens: [
+    factories.subgraphToken.transient({ symbol: 'wstETH' }).build(),
+    factories.subgraphToken.transient({ symbol: 'rETH' }).build(),
+    factories.subgraphToken.transient({ symbol: 'sfrxETH' }).build(),
+  ],
+});
+
 export const getForkedPools = async (
   provider: JsonRpcProvider,
   pools: SubgraphPoolBase[] = [B_50WBTC_50WETH]

--- a/balancer-js/src/test/lib/mainnetPools.ts
+++ b/balancer-js/src/test/lib/mainnetPools.ts
@@ -71,6 +71,15 @@ export const wstETH_rETH_sfrxETH = factories.subgraphPoolBase.build({
   ],
 });
 
+export const UZD_bbausd3 = factories.subgraphPoolBase.build({
+  id: '0xec3626fee40ef95e7c0cbb1d495c8b67b34d398300000000000000000000053d',
+  address: '0xec3626fee40ef95e7c0cbb1d495c8b67b34d3983'.toLowerCase(),
+  tokens: [
+    factories.subgraphToken.transient({ symbol: 'UZD' }).build(),
+    factories.subgraphToken.transient({ symbol: 'bb-a-USD' }).build(),
+  ],
+});
+
 export const getForkedPools = async (
   provider: JsonRpcProvider,
   pools: SubgraphPoolBase[] = [B_50WBTC_50WETH]

--- a/balancer-js/src/test/lib/utils.ts
+++ b/balancer-js/src/test/lib/utils.ts
@@ -1,3 +1,5 @@
+import dotenv from 'dotenv';
+
 import { BigNumber, BigNumberish, formatFixed } from '@ethersproject/bignumber';
 import { hexlify, zeroPad } from '@ethersproject/bytes';
 import { AddressZero, MaxUint256, WeiPerEther } from '@ethersproject/constants';
@@ -40,6 +42,8 @@ import polygonPools from '../fixtures/pools-polygon.json';
 import { PoolsJsonRepository } from './pools-json-repository';
 import { Contracts } from '@/modules/contracts/contracts.module';
 
+dotenv.config();
+
 export interface TxResult {
   transactionReceipt: TransactionReceipt;
   balanceDeltas: BigNumber[];
@@ -50,6 +54,20 @@ export interface TxResult {
 const jsonPools = {
   [Network.MAINNET]: mainnetPools,
   [Network.POLYGON]: polygonPools,
+};
+
+export const RPC_URLS: Record<number, string> = {
+  [Network.MAINNET]: `http://127.0.0.1:8545`,
+  [Network.GOERLI]: `http://127.0.0.1:8000`,
+  [Network.POLYGON]: `http://127.0.0.1:8137`,
+  [Network.ARBITRUM]: `http://127.0.0.1:8161`,
+};
+
+export const FORK_NODES: Record<number, string> = {
+  [Network.MAINNET]: `${process.env.ALCHEMY_URL}`,
+  [Network.GOERLI]: `${process.env.ALCHEMY_URL_GOERLI}`,
+  [Network.POLYGON]: `${process.env.ALCHEMY_URL_POLYGON}`,
+  [Network.ARBITRUM]: `${process.env.ALCHEMY_URL_ARBITRUM}`,
 };
 
 /**

--- a/balancer-js/src/test/lib/utils.ts
+++ b/balancer-js/src/test/lib/utils.ts
@@ -87,7 +87,7 @@ export const forkSetup = async (
   balances: string[],
   jsonRpcUrl: string,
   blockNumber?: number,
-  isVyperMapping = false
+  isVyperMapping: boolean[] = Array(tokens.length).fill(false)
 ): Promise<void> => {
   await signer.provider.send('hardhat_reset', [
     {
@@ -110,7 +110,7 @@ export const forkSetup = async (
       tokens[i],
       slots[i],
       balances[i],
-      isVyperMapping
+      isVyperMapping[i]
     );
 
     // Approve appropriate allowances so that vault contract can move tokens


### PR DESCRIPTION
Also took the opportunity to:
- Refactor exit Composable Stable V3 integration tests to reuse existing test helpers
- Extracted some helper constants to test utils so they can be reused