### PR TITLE
Move coingecko settings from token prices file to config

### DIFF
--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -56,6 +56,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
+    },
     pools: {
       wETHwstETH: {
         id: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080',
@@ -121,6 +127,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: '',
+        platformId: 'polygon-pos',
+      },
+    },
     pools: {},
     poolsToIgnore: [
       '0x600bd01b6526611079e12e1ff93aba7a3e34226f', // This pool has rateProviders with incorrect scaling
@@ -172,6 +184,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'arbitrum-one',
+      },
+    },
     pools: {},
     sorConnectingTokens: [
       {
@@ -202,6 +220,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
+    },
     pools: {},
   },
   [Network.ROPSTEN]: {
@@ -221,6 +245,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       subgraph: '',
       gaugesSubgraph:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges',
+    },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
     },
     pools: {},
   },
@@ -243,6 +273,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-rinkeby-v2',
       gaugesSubgraph:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges',
+    },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
     },
     pools: {},
   },
@@ -279,6 +315,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
+    },
     pools: {},
     sorConnectingTokens: [
       {
@@ -310,6 +352,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
           '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // USDC
           '0x4200000000000000000000000000000000000006', // WETH
         ],
+      },
+    },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'optimism',
       },
     },
     urls: {
@@ -348,6 +396,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2',
       gaugesSubgraph:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain',
+    },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'xdai',
+        platformId: 'xdai',
+      },
     },
     pools: {},
     sorConnectingTokens: [
@@ -389,6 +443,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/beethovenxfi/fantom-blocks',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'ftm',
+        platformId: 'fantom',
+      },
+    },
     pools: {},
     poolsToIgnore: [],
     sorConnectingTokens: [
@@ -428,6 +488,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       subgraph:
         'https://api.studio.thegraph.com/proxy/24660/balancer-sepolia-v2/v0.0.1',
     },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'ethereum',
+      },
+    },
     pools: {},
     poolsToIgnore: [],
     sorConnectingTokens: [],
@@ -461,6 +527,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     urls: {
       subgraph:
         'https://api.studio.thegraph.com/query/24660/balancer-polygon-zkevm-v2/v0.0.2',
+    },
+    thirdParty: {
+      coingecko: {
+        nativeAssetId: 'eth',
+        platformId: 'polygon-zkevm',
+      },
     },
     pools: {},
     poolsToIgnore: [],

--- a/balancer-js/src/modules/sor/token-price/coingeckoTokenPriceService.ts
+++ b/balancer-js/src/modules/sor/token-price/coingeckoTokenPriceService.ts
@@ -1,5 +1,7 @@
 import { TokenPriceService } from '@balancer-labs/sor';
 import axios from 'axios';
+import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
+import { Network, BalancerNetworkConfig } from '@/types';
 
 export class CoingeckoTokenPriceService implements TokenPriceService {
   constructor(private readonly chainId: number) {}
@@ -37,36 +39,14 @@ export class CoingeckoTokenPriceService implements TokenPriceService {
   }
 
   private get platformId(): string {
-    switch (this.chainId) {
-      case 1:
-        return 'ethereum';
-      case 42:
-        return 'ethereum';
-      case 137:
-        return 'polygon-pos';
-      case 42161:
-        return 'arbitrum-one';
-      case 100:
-        return 'xdai';
-    }
-
-    return '2';
+    const networkConfig: BalancerNetworkConfig =
+      BALANCER_NETWORK_CONFIG[this.chainId as Network];
+    return networkConfig.thirdParty.coingecko.platformId || '2';
   }
 
   private get nativeAssetId(): string {
-    switch (this.chainId) {
-      case 1:
-        return 'eth';
-      case 42:
-        return 'eth';
-      case 137:
-        return '';
-      case 42161:
-        return 'eth';
-      case 100:
-        return 'xdai';
-    }
-
-    return '';
+    const networkConfig: BalancerNetworkConfig =
+      BALANCER_NETWORK_CONFIG[this.chainId as Network];
+    return networkConfig.thirdParty.coingecko.nativeAssetId || '';
   }
 }

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -106,6 +106,12 @@ export interface BalancerNetworkConfig {
     gaugesSubgraph?: string;
     blockNumberSubgraph?: string;
   };
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: string;
+      platformId: string;
+    };
+  };
   pools: {
     wETHwstETH?: PoolReference;
   };


### PR DESCRIPTION
Moving Coingecko `platformId` and `nativeAssetId` to the config files instead of being inside coingecko, so that these settings aren't missed when adding a new network. Also added settings for zkevm. 