### PR TITLE
Add bptPrice calculation to liquidity service

### DIFF
--- a/balancer-js/examples/pools/liquidity.ts
+++ b/balancer-js/examples/pools/liquidity.ts
@@ -6,23 +6,23 @@ const sdk = new BalancerSDK({
 });
 
 const { pools } = sdk;
-const { data } = sdk;
 
 (() => {
   [
-    // '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d',
-    // '0x2f4eb100552ef93840d5adc30560e5513dfffacb000000000000000000000334',
+    '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d',
+    '0x2f4eb100552ef93840d5adc30560e5513dfffacb000000000000000000000334',
     '0xc065798f227b49c150bcdc6cdc43149a12c4d75700020000000000000000010b',
   ].forEach(async (poolId) => {
     const pool = await pools.find(poolId);
     if (pool) {
       const liquidity = await pools.liquidity(pool);
+      const bptPrice = await pools.bptPrice(pool);
       console.table([
         {
           pool: pool.name,
           totalShares: pool.totalShares,
-          liquidity: liquidity,
-          bptPrice: parseFloat(liquidity) / parseFloat(pool.totalShares),
+          liquidity,
+          bptPrice,
         },
       ]);
     }

--- a/balancer-js/src/modules/liquidity/liquidity.module.ts
+++ b/balancer-js/src/modules/liquidity/liquidity.module.ts
@@ -3,7 +3,6 @@ import { PoolAttribute } from '../data';
 import { PoolTypeConcerns } from '../pools/pool-type-concerns';
 import { BigNumber } from '@ethersproject/bignumber';
 import { formatFixed, parseFixed } from '@/lib/utils/math';
-import { WeiPerEther } from '@ethersproject/constants';
 
 const SCALE = 18;
 

--- a/balancer-js/src/modules/liquidity/liquidity.module.ts
+++ b/balancer-js/src/modules/liquidity/liquidity.module.ts
@@ -3,6 +3,7 @@ import { PoolAttribute } from '../data';
 import { PoolTypeConcerns } from '../pools/pool-type-concerns';
 import { BigNumber } from '@ethersproject/bignumber';
 import { formatFixed, parseFixed } from '@/lib/utils/math';
+import { WeiPerEther } from '@ethersproject/constants';
 
 const SCALE = 18;
 
@@ -90,5 +91,10 @@ export class Liquidity {
     const totalLiquidity = totalSubPoolLiquidity.add(parsedTokenLiquidity);
 
     return formatFixed(totalLiquidity, SCALE);
+  }
+
+  async getBptPrice(pool: Pool): Promise<string> {
+    const liquidity = await this.getLiquidity(pool);
+    return (parseFloat(liquidity) / parseFloat(pool.totalShares)).toString();
   }
 }

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -298,13 +298,23 @@ export class Pools implements Findable<PoolWithMethods> {
   }
 
   /**
-   * Calculates total liquidity of the pool
+   * Calculates total pool liquidity in USD
    *
    * @param pool
-   * @returns
+   * @returns total pool liquidity in USD
    */
   async liquidity(pool: Pool): Promise<string> {
     return this.liquidityService.getLiquidity(pool);
+  }
+
+  /**
+   * Calculates pool's BPT price in USD
+   *
+   * @param pool
+   * @returns pool's BPT price in USD
+   */
+  async bptPrice(pool: Pool): Promise<string> {
+    return this.liquidityService.getBptPrice(pool);
   }
 
   /**


### PR DESCRIPTION
See [this Asana task](https://app.asana.com/0/1201380039585484/1204551609513252/f) for more info.

The initial suggestion was to add `bptPrice` as an extra field to liquidity, but that would add a breaking change, so I added a separate external method that uses liquidity service to calculate the bptPrice in USD.

Let me know if you think this approach makes sense or if you'd rather update liquidity service to return both `liquidity` and `bptPrice` at the same time.