### PR TITLE
Fix Polygon integration tests failing (WIP)

### DIFF
--- a/balancer-js/src/modules/pools/impermanentLoss/impermanentLoss.integration.spec.ts
+++ b/balancer-js/src/modules/pools/impermanentLoss/impermanentLoss.integration.spec.ts
@@ -5,7 +5,8 @@
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { ImpermanentLossService } from '@/modules/pools/impermanentLoss/impermanentLossService';
 import { BalancerSDK } from '@/modules/sdk.module';
-import { Network, Pool } from '@/types';
+import { getPoolFromFile } from '@/test/lib/utils';
+import { Network } from '@/types';
 import { expect } from 'chai';
 
 const TEST_DATA: { [key: string]: { poolId: string } } = {
@@ -35,24 +36,15 @@ const service = new ImpermanentLossService(
   sdk.data.tokenHistoricalPrices
 );
 
-const getPool = async (poolId: string): Promise<Pool> => {
-  const pool = await sdk.pools.find(poolId);
-  if (!pool) {
-    throw new Error('poll not found');
-  }
-  return pool;
-};
 /*
  * REALLY MORE A LIST OF USE CASE SCENARIOS THAN AN INTEGRATION TEST.
- *
- * TODO: add stubbing
  */
-describe.skip('ImpermanentLossService', function () {
+describe('ImpermanentLossService', function () {
   this.timeout(60000);
   context('when queried for Composable Stable Pool', () => {
     it('should return an IL gte 0', async () => {
       const testData = TEST_DATA.ComposableStablePool;
-      const pool = await getPool(testData.poolId);
+      const pool = await getPoolFromFile(testData.poolId, network);
       const timestamp = 1666601608;
       const loss = await service.calcImpLoss(timestamp, pool);
       expect(loss).gte(0);
@@ -61,7 +53,7 @@ describe.skip('ImpermanentLossService', function () {
   context('when queried for Weighted Pool', () => {
     it('should return an IL gte 0', async () => {
       const testData = TEST_DATA.WeightedPool;
-      const pool = await getPool(testData.poolId);
+      const pool = await getPoolFromFile(testData.poolId, network);
       const timestamp = 1666601608;
       const loss = await service.calcImpLoss(timestamp, pool);
       expect(loss).gte(0);
@@ -70,7 +62,7 @@ describe.skip('ImpermanentLossService', function () {
   context('when queried for pool Weighted Pool with missing price', () => {
     it('should throw an exception', async () => {
       const testData = TEST_DATA.WeightedPoolWithMissingPrice;
-      const pool = await getPool(testData.poolId);
+      const pool = await getPoolFromFile(testData.poolId, network);
       const timestamp = 1666276501;
       try {
         await service.calcImpLoss(timestamp, pool);
@@ -84,7 +76,7 @@ describe.skip('ImpermanentLossService', function () {
   context('when queried for pool Weighted Pool with missing user data', () => {
     it('should throw an exception', async () => {
       const testData = TEST_DATA.WeightedPoolWithMissingUserData;
-      const pool = await getPool(testData.poolId);
+      const pool = await getPoolFromFile(testData.poolId, network);
       const timestamp = Date.now() + 3600000; //1 hour from now
       try {
         await service.calcImpLoss(timestamp, pool);

--- a/balancer-js/src/modules/pools/pool-types/concerns/fx/liquidity.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/fx/liquidity.concern.integration.spec.ts
@@ -2,13 +2,10 @@
 import { expect } from 'chai';
 import dotenv from 'dotenv';
 import { formatFixed, parseFixed } from '@ethersproject/bignumber';
-import { Contract } from '@ethersproject/contracts';
 import { JsonRpcProvider } from '@ethersproject/providers';
 
 import { FXPool__factory } from '@/contracts';
-import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
 import { SolidityMaths } from '@/lib/utils/solidityMaths';
-import { Pools } from '@/modules/pools';
 import { BalancerSDK } from '@/modules/sdk.module';
 import {
   FORK_NODES,
@@ -17,7 +14,7 @@ import {
   RPC_URLS,
   updateFromChain,
 } from '@/test/lib/utils';
-import { Network, PoolWithMethods } from '@/types';
+import { Network, Pool } from '@/types';
 
 dotenv.config();
 
@@ -29,7 +26,7 @@ const provider = new JsonRpcProvider(rpcUrlLocal, network);
 const signer = provider.getSigner();
 const testPoolId =
   '0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702';
-let pool: PoolWithMethods;
+let pool: Pool;
 const blockNumber = 43015527;
 
 describe('FX Pool - Calculate Liquidity', () => {
@@ -40,24 +37,25 @@ describe('FX Pool - Calculate Liquidity', () => {
   const balancer = new BalancerSDK(sdkConfig);
 
   before(async () => {
-    let testPool = await getPoolFromFile(testPoolId, network);
-    testPool = await updateFromChain(testPool, network, provider);
+    pool = await getPoolFromFile(testPoolId, network);
 
     // Setup forked network, set initial token balances and allowances
     await forkSetup(signer, [], [], [], rpcUrlRemote as string, blockNumber);
 
     // Update pool info with onchain state from fork block no
-    pool = Pools.wrap(testPool, BALANCER_NETWORK_CONFIG[network]);
+    pool = await updateFromChain(pool, network, provider);
   });
 
   it('should match liquidity from contract with 5% of margin error', async () => {
     const liquidity = await balancer.pools.liquidity(pool);
-    const poolInterface = FXPool__factory.createInterface();
-    const poolContract = new Contract(pool.address, poolInterface, provider);
+    const poolContract = FXPool__factory.connect(pool.address, provider);
     const liquidityFromContract = (
       await poolContract.liquidity()
     ).total_.toBigInt();
     const liquidityBigInt = parseFixed(liquidity, 18).toBigInt();
+    console.log('liquidityBigInt      ', liquidityBigInt);
+    console.log('liquidityFromContract', liquidityFromContract);
+    console.log('totalLiquidity       ', pool.totalLiquidity);
     // expecting 5% of margin error
     expect(
       parseFloat(

--- a/balancer-js/src/modules/pools/pool-types/concerns/fx/liquidity.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/fx/liquidity.concern.integration.spec.ts
@@ -1,22 +1,31 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/fx/liquidity.concern.integration.spec.ts
-import dotenv from 'dotenv';
-import { Network, PoolWithMethods } from '@/types';
-import { forkSetup, TestPoolHelper } from '@/test/lib/utils';
-import { ethers } from 'hardhat';
-import { BalancerSDK } from '@/modules/sdk.module';
-import { FXPool__factory } from '@/contracts';
-import { Contract } from '@ethersproject/contracts';
 import { expect } from 'chai';
+import dotenv from 'dotenv';
 import { formatFixed, parseFixed } from '@ethersproject/bignumber';
+import { Contract } from '@ethersproject/contracts';
+import { JsonRpcProvider } from '@ethersproject/providers';
+
+import { FXPool__factory } from '@/contracts';
+import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
 import { SolidityMaths } from '@/lib/utils/solidityMaths';
+import { Pools } from '@/modules/pools';
+import { BalancerSDK } from '@/modules/sdk.module';
+import {
+  FORK_NODES,
+  forkSetup,
+  getPoolFromFile,
+  RPC_URLS,
+  updateFromChain,
+} from '@/test/lib/utils';
+import { Network, PoolWithMethods } from '@/types';
 
 dotenv.config();
 
 const network = Network.POLYGON;
-const { ALCHEMY_URL_POLYGON: rpcUrlArchive } = process.env;
-const rpcUrlLocal = 'http://127.0.0.1:8137';
+const rpcUrlRemote = FORK_NODES[network];
+const rpcUrlLocal = RPC_URLS[network];
 
-const provider = new ethers.providers.JsonRpcProvider(rpcUrlLocal, network);
+const provider = new JsonRpcProvider(rpcUrlLocal, network);
 const signer = provider.getSigner();
 const testPoolId =
   '0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702';
@@ -29,23 +38,19 @@ describe('FX Pool - Calculate Liquidity', () => {
     rpcUrl: rpcUrlLocal,
   };
   const balancer = new BalancerSDK(sdkConfig);
+
   before(async () => {
-    const testPool = new TestPoolHelper(
-      testPoolId,
-      network,
-      rpcUrlLocal,
-      blockNumber
-    );
-    // Gets initial pool info from Subgraph
-    pool = await testPool.getPool();
+    let testPool = await getPoolFromFile(testPoolId, network);
+    testPool = await updateFromChain(testPool, network, provider);
 
     // Setup forked network, set initial token balances and allowances
-    await forkSetup(signer, [], [], [], rpcUrlArchive as string, undefined);
+    await forkSetup(signer, [], [], [], rpcUrlRemote as string, blockNumber);
 
     // Update pool info with onchain state from fork block no
-    pool = await testPool.getPool();
+    pool = Pools.wrap(testPool, BALANCER_NETWORK_CONFIG[network]);
   });
-  it('calculating liquidity', async () => {
+
+  it('should match liquidity from contract with 5% of margin error', async () => {
     const liquidity = await balancer.pools.liquidity(pool);
     const poolInterface = FXPool__factory.createInterface();
     const poolContract = new Contract(pool.address, poolInterface, provider);

--- a/balancer-js/src/modules/pools/pool-types/concerns/gyro/liquidity.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/gyro/liquidity.concern.integration.spec.ts
@@ -1,49 +1,53 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/gyro/liquidity.concern.integration.spec.ts
-import dotenv from 'dotenv';
-import { Network, PoolWithMethods } from '@/types';
-import { forkSetup, TestPoolHelper } from '@/test/lib/utils';
-import { ethers } from 'hardhat';
-import { BalancerSDK } from '@/modules/sdk.module';
 import { expect } from 'chai';
+import dotenv from 'dotenv';
 import { formatFixed, parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
+
 import { SolidityMaths } from '@/lib/utils/solidityMaths';
+import { BalancerSDK } from '@/modules/sdk.module';
+import {
+  FORK_NODES,
+  forkSetup,
+  getPoolFromFile,
+  RPC_URLS,
+  updateFromChain,
+} from '@/test/lib/utils';
+import { Network, Pool } from '@/types';
 
 dotenv.config();
 
-const network = Network.POLYGON;
-const { ALCHEMY_URL_POLYGON: rpcUrlArchive } = process.env;
-const rpcUrlLocal = 'http://127.0.0.1:8137';
-
-const provider = new ethers.providers.JsonRpcProvider(rpcUrlLocal, network);
-const signer = provider.getSigner();
-const blockNumber = 43015527;
-
 describe('Gyro Pools - Calculate Liquidity', () => {
+  const network = Network.POLYGON;
+  const rpcUrlRemote = FORK_NODES[network];
+  const rpcUrlLocal = RPC_URLS[network];
+  const provider = new JsonRpcProvider(rpcUrlLocal, network);
+  const signer = provider.getSigner();
+  const blockNumber = 43015527;
   const sdkConfig = {
     network,
     rpcUrl: rpcUrlLocal,
   };
   const balancer = new BalancerSDK(sdkConfig);
+  let testPoolId: string;
+  let pool: Pool;
+
+  beforeEach(async () => {
+    pool = await getPoolFromFile(testPoolId, network);
+
+    // Setup forked network, set initial token balances and allowances
+    await forkSetup(signer, [], [], [], rpcUrlRemote as string, blockNumber);
+
+    // Update pool info with onchain state from fork block no
+    pool = await updateFromChain(pool, network, provider);
+  });
+
   context('GyroE Pools', () => {
-    const testPoolId =
-      '0x97469e6236bd467cd147065f77752b00efadce8a0002000000000000000008c0';
-    let pool: PoolWithMethods;
     before(async () => {
-      const testPool = new TestPoolHelper(
-        testPoolId,
-        network,
-        rpcUrlLocal,
-        blockNumber
-      );
-      // Gets initial pool info from Subgraph
-      pool = await testPool.getPool();
-
-      // Setup forked network, set initial token balances and allowances
-      await forkSetup(signer, [], [], [], rpcUrlArchive as string, undefined);
-
-      // Update pool info with onchain state from fork block no
-      pool = await testPool.getPool();
+      testPoolId =
+        '0x97469e6236bd467cd147065f77752b00efadce8a0002000000000000000008c0';
     });
+
     it('calculating liquidity', async () => {
       const liquidity = await balancer.pools.liquidity(pool);
       const liquidityFromContract = parseFixed(
@@ -51,6 +55,8 @@ describe('Gyro Pools - Calculate Liquidity', () => {
         18
       ).toBigInt();
       const liquidityBigInt = parseFixed(liquidity, 18).toBigInt();
+      console.log('liquidityBigInt      ', liquidityBigInt);
+      console.log('liquidityFromContract', liquidityFromContract);
       // expecting 5% of margin error
       expect(
         parseFloat(
@@ -62,26 +68,13 @@ describe('Gyro Pools - Calculate Liquidity', () => {
       ).to.be.closeTo(1, 0.05);
     });
   });
+
   context('Gyro V2 Pools', () => {
-    const testPoolId =
-      '0xdac42eeb17758daa38caf9a3540c808247527ae3000200000000000000000a2b';
-    let pool: PoolWithMethods;
     before(async () => {
-      const testPool = new TestPoolHelper(
-        testPoolId,
-        network,
-        rpcUrlLocal,
-        blockNumber
-      );
-      // Gets initial pool info from Subgraph
-      pool = await testPool.getPool();
-
-      // Setup forked network, set initial token balances and allowances
-      await forkSetup(signer, [], [], [], rpcUrlArchive as string, undefined);
-
-      // Update pool info with onchain state from fork block no
-      pool = await testPool.getPool();
+      testPoolId =
+        '0xdac42eeb17758daa38caf9a3540c808247527ae3000200000000000000000a2b';
     });
+
     it('calculating liquidity', async () => {
       const liquidity = await balancer.pools.liquidity(pool);
       const liquidityFromContract = parseFixed(
@@ -89,6 +82,9 @@ describe('Gyro Pools - Calculate Liquidity', () => {
         18
       ).toBigInt();
       const liquidityBigInt = parseFixed(liquidity, 18).toBigInt();
+
+      console.log('liquidityBigInt      ', liquidityBigInt);
+      console.log('liquidityFromContract', liquidityFromContract);
       // expecting 5% of margin error
       expect(
         parseFloat(
@@ -100,26 +96,13 @@ describe('Gyro Pools - Calculate Liquidity', () => {
       ).to.be.closeTo(1, 0.05);
     });
   });
+
   context('Gyro V3 Pools', () => {
-    const testPoolId =
-      '0x17f1ef81707811ea15d9ee7c741179bbe2a63887000100000000000000000799';
-    let pool: PoolWithMethods;
     before(async () => {
-      const testPool = new TestPoolHelper(
-        testPoolId,
-        network,
-        rpcUrlLocal,
-        blockNumber
-      );
-      // Gets initial pool info from Subgraph
-      pool = await testPool.getPool();
-
-      // Setup forked network, set initial token balances and allowances
-      await forkSetup(signer, [], [], [], rpcUrlArchive as string, undefined);
-
-      // Update pool info with onchain state from fork block no
-      pool = await testPool.getPool();
+      testPoolId =
+        '0x17f1ef81707811ea15d9ee7c741179bbe2a63887000100000000000000000799';
     });
+
     it('calculating liquidity', async () => {
       const liquidity = await balancer.pools.liquidity(pool);
       const liquidityFromContract = parseFixed(
@@ -127,6 +110,8 @@ describe('Gyro Pools - Calculate Liquidity', () => {
         18
       ).toBigInt();
       const liquidityBigInt = parseFixed(liquidity, 18).toBigInt();
+      console.log('liquidityBigInt      ', liquidityBigInt);
+      console.log('liquidityFromContract', liquidityFromContract);
       // expecting 5% of margin error
       expect(
         parseFloat(

--- a/balancer-js/src/test/fixtures/pools-polygon.json
+++ b/balancer-js/src/test/fixtures/pools-polygon.json
@@ -8521,6 +8521,70 @@
         "strategyType": 0,
         "swapsCount": "71",
         "holdersCount": "3"
+      },
+      {
+        "name": "20WETH-80WARU",
+        "id": "0x017fe2f89a34a3485b66e50b3b25c588d70a787a0002000000000000000008c7",
+        "totalLiquidity": "48.89105490659764191279489079537549",
+        "symbol": "20WETH-80WARU",
+        "poolType": "Weighted",
+        "poolTypeVersion": 1,
+        "swapFee": "0.003",
+        "swapEnabled": true,
+        "protocolYieldFeeCache": null,
+        "protocolSwapFeeCache": null,
+        "amp": null,
+        "owner": "0x9fdcf9e4c3b9c8606803fada2734fabda2d24dc8",
+        "factory": "0x8e9aa87e45e92bad84d5f8dd1bff34fb92637de9",
+        "tokensList": [
+          "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+          "0xe3627374ac4baf5375e79251b0af23afc450fc0e"
+        ],
+        "totalShares": "12030.842160148105621411",
+        "totalSwapFee": "11.07356512455935245583458460953131",
+        "totalSwapVolume": "3691.188374853117485278194869843758",
+        "createTime": 1668293586,
+        "mainIndex": null,
+        "wrappedIndex": null,
+        "upperTarget": null,
+        "lowerTarget": null,
+        "isInRecoveryMode": null,
+        "strategyType": 2,
+        "swapsCount": "650",
+        "holdersCount": "3",
+        "priceRateProviders": [],
+        "tokens": [
+          {
+            "id": "0x017fe2f89a34a3485b66e50b3b25c588d70a787a0002000000000000000008c7-0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+            "symbol": "WETH",
+            "decimals": 18,
+            "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+            "balance": "0.027247473728902608",
+            "managedBalance": "0",
+            "weight": "0.2",
+            "priceRate": "1",
+            "token": {
+              "latestUSDPrice": "1827.391221834434135853254006078268",
+              "pool": null
+            },
+            "isExemptFromYieldProtocolFee": null
+          },
+          {
+            "id": "0x017fe2f89a34a3485b66e50b3b25c588d70a787a0002000000000000000008c7-0xe3627374ac4baf5375e79251b0af23afc450fc0e",
+            "symbol": "WARU",
+            "decimals": 18,
+            "address": "0xe3627374ac4baf5375e79251b0af23afc450fc0e",
+            "balance": "130545.7637851600531336",
+            "managedBalance": "0",
+            "weight": "0.8",
+            "priceRate": "1",
+            "token": {
+              "latestUSDPrice": null,
+              "pool": null
+            },
+            "isExemptFromYieldProtocolFee": null
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Context: several integration tests rely on subgraph data, which eventually start failing due to old blockNumbers being pruned.

This PR fixes this issue by stubbing data and updating them by fetching directly from chain.

Note: this is still a work in progress because liquidity tests are failing after the refactor.