### PR TITLE
Refresh pool data

### DIFF
--- a/balancer-js/examples/data/pools.ts
+++ b/balancer-js/examples/data/pools.ts
@@ -1,11 +1,11 @@
-import { Network } from '../../src/index';
-import { BalancerSDK } from '../../src/modules/sdk.module';
+import { BalancerSDK, Network } from '@balancer-labs/sdk';
 
 const sdk = new BalancerSDK({ 
-    network: Network.MAINNET, 
-    rpcUrl: '' 
-  });
-const { pools } = sdk.data;
+  network: Network.MAINNET, 
+  rpcUrl: 'https://rpc.ankr.com/eth'
+});
+
+const { pools, poolsOnChain } = sdk.data;
 
 async function main() {
 
@@ -23,6 +23,14 @@ async function main() {
 
   result = await pools.where(pool => POOL_IDs.includes(pool.id));
   console.log('Filter pools by attributes', result);
+
+  // Fefetch on-chain balances for a given pool
+  const pool = await pools.find(POOL_ID1);
+  for (const idx in pool!.tokens) {
+    pool!.tokens[idx].balance = '0';
+  }
+  const onchain = await poolsOnChain.refresh(pool!);
+  console.log('onchain pool', onchain);
 }
 
 main();

--- a/balancer-js/examples/pools/join/join-with-eth.ts
+++ b/balancer-js/examples/pools/join/join-with-eth.ts
@@ -3,7 +3,7 @@
  * Note: same as join.ts but adding the `value` parameter to the transaction
  * 
  * Run with:
- * yarn example ./examples/pools/join/eth-join.ts
+ * yarn example ./examples/pools/join/join-with-eth.ts
  */
 import {
   BalancerSDK,
@@ -18,12 +18,10 @@ async function join() {
     rpcUrl: 'http://127.0.0.1:8545', // Using local fork for simulation
   })
 
-  const { provider } = balancer
-  const signer = provider.getSigner()
-  const address = await signer.getAddress()
+  const { poolsOnChain, pools } = balancer.data
 
   // 50/50 WBTC/WETH Pool
-  const pool = await balancer.pools.find('0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e')
+  let pool = await pools.find('0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e')
   if (!pool) throw Error('Pool not found')
 
   // Tokens that will be provided to pool by joiner
@@ -38,6 +36,10 @@ async function join() {
 
   const amountsIn = ['10000000', '1000000000000000000']
 
+  const { provider } = balancer
+  const signer = provider.getSigner()
+  const address = await signer.getAddress()
+
   // Prepare local fork for simulation
   await reset(provider, 17000000)
   await setTokenBalance(provider, address, tokensIn[0], amountsIn[0], slots[0])
@@ -46,17 +48,26 @@ async function join() {
   // Checking balances to confirm success
   const btcBefore = String(await getTokenBalance(tokensIn[0], address, provider))
 
+  // Refresh pool data from chain before building and sending tx
+  pool = await poolsOnChain.refresh(pool)
+
   // Build join transaction
   const slippage = '100' // 100 bps = 1%
-  const { to, data, minBPTOut } = pool.buildJoin(
-    address,
+  const { to, data, minBPTOut } = balancer.pools.buildJoin({
+    pool,
+    userAddress: address,
     tokensIn,
     amountsIn,
     slippage
-  )
+  })
 
   // Calculate price impact
-  const priceImpact = await pool.calcPriceImpact(amountsIn, minBPTOut, true)
+  const priceImpact = balancer.pools.calcPriceImpact({
+    pool,
+    tokenAmounts: amountsIn,
+    bptAmount: minBPTOut,
+    isJoin: true
+  })
 
   // Submit join tx
   const transactionResponse = await signer.sendTransaction({

--- a/balancer-js/src/modules/data/types.ts
+++ b/balancer-js/src/modules/data/types.ts
@@ -18,3 +18,7 @@ export interface Searchable<T> {
   all: () => Promise<T[]>;
   where: (filters: (arg: T) => boolean) => Promise<T[]>;
 }
+
+export interface Cacheable<T> {
+  refresh: (arg: T) => Promise<T>;
+}

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -326,7 +326,7 @@ export class Pools implements Findable<PoolWithMethods> {
   /**
    * Builds join transaction
    *
-   * @param poolId          Pool id
+   * @param pool            Pool
    * @param tokensIn        Token addresses
    * @param amountsIn       Token amounts in EVM scale
    * @param userAddress     User address
@@ -359,7 +359,7 @@ export class Pools implements Findable<PoolWithMethods> {
       amountsIn,
       slippage,
       wrappedNativeAsset:
-        this.networkConfig.addresses.tokens.wrappedNativeAsset,
+        this.networkConfig.addresses.tokens.wrappedNativeAsset.toLowerCase(),
     });
   }
 
@@ -384,7 +384,7 @@ export class Pools implements Findable<PoolWithMethods> {
       bptIn: bptAmount,
       slippage,
       wrappedNativeAsset:
-        this.networkConfig.addresses.tokens.wrappedNativeAsset,
+        this.networkConfig.addresses.tokens.wrappedNativeAsset.toLowerCase(),
       shouldUnwrapNativeAsset: false,
       toInternalBalance: false,
     });
@@ -477,7 +477,7 @@ export class Pools implements Findable<PoolWithMethods> {
     pool,
     tokenAmounts,
     bptAmount,
-    isJoin
+    isJoin,
   }: {
     pool: Pool;
     tokenAmounts: string[];
@@ -490,9 +490,8 @@ export class Pools implements Findable<PoolWithMethods> {
       tokenAmounts.map(BigInt),
       BigInt(bptAmount),
       isJoin
-    )
+    );
   }
-
 
   /**
    * Gets info required to build generalised exit transaction

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -468,6 +468,33 @@ export class Pools implements Findable<PoolWithMethods> {
   }
 
   /**
+   * Calculates price impact for an action on a pool
+   *
+   * @param pool
+   * @returns percentage as a string in EVM scale
+   */
+  calcPriceImpact({
+    pool,
+    tokenAmounts,
+    bptAmount,
+    isJoin
+  }: {
+    pool: Pool;
+    tokenAmounts: string[];
+    bptAmount: string;
+    isJoin: boolean;
+  }): string {
+    const concerns = PoolTypeConcerns.from(pool.poolType);
+    return concerns.priceImpactCalculator.calcPriceImpact(
+      pool,
+      tokenAmounts.map(BigInt),
+      BigInt(bptAmount),
+      isJoin
+    )
+  }
+
+
+  /**
    * Gets info required to build generalised exit transaction
    *
    * @param poolId          Pool id

--- a/balancer-js/src/test/factories/data.ts
+++ b/balancer-js/src/test/factories/data.ts
@@ -6,6 +6,7 @@ import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
 import { PoolJoinExitRepository, PoolSharesRepository } from '@/modules/data';
 import {
   BalancerDataRepositories,
+  Cacheable,
   Findable,
   LiquidityGauge,
   Network,
@@ -39,11 +40,12 @@ export const findable = <T, P = string, V = any>(
 
 export const stubbed = <T, P = string, V = any>(
   value: unknown
-): Findable<T, P, V> & Searchable<T> => ({
+): Findable<T, P, V> & Searchable<T> & Cacheable<T> => ({
   find: (id: string) => Promise.resolve(value as T),
   findBy: (param: P, _: V) => Promise.resolve(value as T),
   all: () => Promise.resolve([value as T]),
   where: (filters: (arg: T) => boolean) => Promise.resolve([value as T]),
+  refresh: (obj: T) => Promise.resolve(value as T),
 });
 
 export const aaveRates = {

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -13,6 +13,7 @@ import type {
   LiquidityGauge,
   PoolAttribute,
   TokenAttribute,
+  Cacheable,
 } from '@/modules/data/types';
 import type {
   BaseFeeDistributor,
@@ -127,7 +128,9 @@ export interface BalancerDataRepositories {
   // Does it need to be different from the pools repository?
   poolsForSor: SubgraphPoolDataService;
   // Perhaps better to use a function to get upto date balances when needed.
-  poolsOnChain: Findable<Pool, PoolAttribute> & Searchable<Pool>;
+  poolsOnChain: Findable<Pool, PoolAttribute> &
+    Searchable<Pool> &
+    Cacheable<Pool>;
   // Replace with a swapFeeRepository, we don't need historic pools for any other reason than to get the swap fee
   yesterdaysPools?: Findable<Pool, PoolAttribute> & Searchable<Pool>;
   tokenPrices: Findable<Price>;


### PR DESCRIPTION
* Exposing join and exit functions on the pools module instead of the pool model (which is wrapped). This way, the pool state can be passed directly. Since the frontend already fetches and stores pools as variables, I believe there is no need for the "Wrapped" version. We can consider refactoring it out later. https://github.com/balancer/balancer-sdk/pull/458/files#diff-f4169f56974e94f924689e0ff5c152879afa7eae66ef87c442a87096302a09b0R461
* The SubgraphOnChain repository now has the capability to refresh just one pool instead of refreshing all of them. Faster for join and exit cases. https://github.com/balancer/balancer-sdk/pull/458/files#diff-e531f833d92ed2706fec5a309890f010dc43c1b6438ef9d6a7f59be454e03ab4R123