### PR TITLE
Use average block time for chains without blocks subgraph

### DIFF
--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -405,6 +405,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         platformId: 'xdai',
       },
     },
+    averageBlockTime: 5,
     pools: {},
     sorConnectingTokens: [
       {
@@ -539,6 +540,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         platformId: 'polygon-zkevm',
       },
     },
+    averageBlockTime: 5,
     pools: {},
     poolsToIgnore: [],
     sorConnectingTokens: [

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -540,7 +540,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         platformId: 'polygon-zkevm',
       },
     },
-    averageBlockTime: 5,
+    averageBlockTime: 4,
     pools: {},
     poolsToIgnore: [],
     sorConnectingTokens: [

--- a/balancer-js/src/modules/data/index.ts
+++ b/balancer-js/src/modules/data/index.ts
@@ -139,13 +139,11 @@ export class Data implements BalancerDataRepositories {
         blockHeight: blockDayAgo,
         query: subgraphQuery,
       });
-    }
-
-    // Hardcoding gnosis chain block time to 5 sec.
-    if (networkConfig.chainId === 100) {
+    } else if (networkConfig.averageBlockTime) {
       const blockDayAgo = async () => {
         const blockNumber = await provider.getBlockNumber();
-        return blockNumber - 17280;
+        const blocksPerDay = Math.round(86400 / networkConfig.averageBlockTime!);
+        return blockNumber - blocksPerDay;
       };
 
       this.yesterdaysPools = new PoolsSubgraphRepository({

--- a/balancer-js/src/modules/data/index.ts
+++ b/balancer-js/src/modules/data/index.ts
@@ -142,7 +142,9 @@ export class Data implements BalancerDataRepositories {
     } else if (networkConfig.averageBlockTime) {
       const blockDayAgo = async () => {
         const blockNumber = await provider.getBlockNumber();
-        const blocksPerDay = Math.round(86400 / networkConfig.averageBlockTime!);
+        const blocksPerDay = Math.round(
+          86400 / (networkConfig.averageBlockTime || 2)
+        );
         return blockNumber - blocksPerDay;
       };
 

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -112,7 +112,7 @@ export interface BalancerNetworkConfig {
       platformId: string;
     };
   };
-  averageBlockTime?: number;  // In seconds, used if blockNumberSubgraph not set
+  averageBlockTime?: number; // In seconds, used if blockNumberSubgraph not set
   pools: {
     wETHwstETH?: PoolReference;
   };

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -112,6 +112,7 @@ export interface BalancerNetworkConfig {
       platformId: string;
     };
   };
+  averageBlockTime?: number;  // In seconds, used if blockNumberSubgraph not set
   pools: {
     wETHwstETH?: PoolReference;
   };


### PR DESCRIPTION
We don't have a blocks subgraph for Gnosis Chain or zkEVM, instead set the average block time and fetch based on that for chains without a blocks subgraph set.

Tested with the API and it is correctly calculating volumes for zkEVM, Gnosis and Mainnet