### PR TITLE
Remove tenderly default config

### DIFF
--- a/balancer-js/src/lib/utils/tenderlyHelper.ts
+++ b/balancer-js/src/lib/utils/tenderlyHelper.ts
@@ -15,27 +15,17 @@ export default class TenderlyHelper {
   private opts?;
   private blockNumber: number | undefined;
 
-  constructor(
-    private chainId: number,
-    tenderlyConfig?: BalancerTenderlyConfig
-  ) {
+  constructor(private chainId: number, tenderlyConfig: BalancerTenderlyConfig) {
     const { contracts } = networkAddresses(this.chainId);
     this.vaultAddress = contracts.vault as string;
-    if (tenderlyConfig?.user && tenderlyConfig?.project) {
-      this.tenderlyUrl = `https://api.tenderly.co/api/v1/account/${tenderlyConfig.user}/project/${tenderlyConfig.project}/`;
-    } else {
-      this.tenderlyUrl = 'https://api.balancer.fi/tenderly/';
-    }
+    this.tenderlyUrl = `https://api.tenderly.co/api/v1/account/${tenderlyConfig.user}/project/${tenderlyConfig.project}/`;
+    this.opts = {
+      headers: {
+        'X-Access-Key': tenderlyConfig.accessKey,
+      },
+    };
 
-    if (tenderlyConfig?.accessKey) {
-      this.opts = {
-        headers: {
-          'X-Access-Key': tenderlyConfig.accessKey,
-        },
-      };
-    }
-
-    this.blockNumber = tenderlyConfig?.blockNumber;
+    this.blockNumber = tenderlyConfig.blockNumber;
   }
 
   simulateMulticall = async (

--- a/balancer-js/src/modules/exits/testHelper.ts
+++ b/balancer-js/src/modules/exits/testHelper.ts
@@ -152,10 +152,13 @@ async function setUpForkAndSdk(
   sdk: BalancerSDK;
   signer: JsonRpcSigner;
 }> {
-  // Set tenderly config blockNumber and use default values for other parameters
-  const tenderlyConfig = {
-    blockNumber,
-  };
+  // // Uncomment and set tenderlyConfig on sdk instantiation in order to test using tenderly simulations
+  // const tenderlyConfig = {
+  //   accessKey: process.env.TENDERLY_ACCESS_KEY as string,
+  //   user: process.env.TENDERLY_USER as string,
+  //   project: process.env.TENDERLY_PROJECT as string,
+  //   blockNumber,
+  // };
 
   // Only queries minimal set of addresses
   const subgraphQuery = createSubgraphQuery(pools, blockNumber);
@@ -163,7 +166,6 @@ async function setUpForkAndSdk(
   const sdk = new BalancerSDK({
     network,
     rpcUrl: RPC_URLS[network],
-    tenderly: tenderlyConfig,
     subgraphQuery,
   });
   const provider = new JsonRpcProvider(RPC_URLS[network], network);

--- a/balancer-js/src/modules/joins/joins.module.integration.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.integration.spec.ts
@@ -86,12 +86,16 @@ describe('generalised join execution', async function () {
         ],
         blockNumber
       );
+      // // Uncomment and set tenderlyConfig on sdk instantiation in order to test using tenderly simulations
+      // const tenderlyConfig = {
+      //   accessKey: process.env.TENDERLY_ACCESS_KEY as string,
+      //   user: process.env.TENDERLY_USER as string,
+      //   project: process.env.TENDERLY_PROJECT as string,
+      //   blockNumber,
+      // };
       sdk = new BalancerSDK({
         network,
         rpcUrl,
-        tenderly: {
-          blockNumber, // Set tenderly config blockNumber and use default values for other parameters
-        },
         subgraphQuery,
       });
     });

--- a/balancer-js/src/modules/joins/joins.module.integration.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.integration.spec.ts
@@ -43,7 +43,7 @@ const TEST_BBRFUSD = true;
 
 describe('generalised join execution', async function () {
   this.timeout(30000);
-  const simulationType = SimulationType.VaultModel;
+  const simulationType = SimulationType.Static;
   let network: Network;
   let blockNumber: number;
   let jsonRpcUrl: string;
@@ -209,12 +209,16 @@ describe('generalised join execution', async function () {
         (address) => address.address
       );
       subgraphQuery = createSubgraphQuery(poolAddresses, blockNumber);
+      // // Uncomment and set tenderlyConfig on sdk instantiation in order to test using tenderly simulations
+      // const tenderlyConfig = {
+      //   accessKey: process.env.TENDERLY_ACCESS_KEY as string,
+      //   user: process.env.TENDERLY_USER as string,
+      //   project: process.env.TENDERLY_PROJECT as string,
+      //   blockNumber,
+      // };
       sdk = new BalancerSDK({
         network,
         rpcUrl,
-        tenderly: {
-          blockNumber, // Set tenderly config blockNumber and use default values for other parameters
-        },
         subgraphQuery,
       });
     });
@@ -1087,12 +1091,16 @@ describe('generalised join execution', async function () {
         (address) => address.address
       );
       subgraphQuery = createSubgraphQuery(poolAddresses, blockNumber);
+      // // Uncomment and set tenderlyConfig on sdk instantiation in order to test using tenderly simulations
+      // const tenderlyConfig = {
+      //   accessKey: process.env.TENDERLY_ACCESS_KEY as string,
+      //   user: process.env.TENDERLY_USER as string,
+      //   project: process.env.TENDERLY_PROJECT as string,
+      //   blockNumber,
+      // };
       sdk = new BalancerSDK({
         network,
         rpcUrl,
-        tenderly: {
-          blockNumber, // Set tenderly config blockNumber and use default values for other parameters
-        },
         subgraphQuery,
       });
     });

--- a/balancer-js/src/modules/simulation/simulation.module.ts
+++ b/balancer-js/src/modules/simulation/simulation.module.ts
@@ -27,16 +27,18 @@ export enum SimulationType {
  */
 
 export class Simulation {
-  private tenderlyHelper: TenderlyHelper;
+  private tenderlyHelper?: TenderlyHelper;
   private vaultModel: VaultModel | undefined;
   constructor(
     networkConfig: BalancerNetworkConfig,
     poolDataService?: PoolDataService
   ) {
-    this.tenderlyHelper = new TenderlyHelper(
-      networkConfig.chainId,
-      networkConfig.tenderly
-    );
+    if (networkConfig.tenderly) {
+      this.tenderlyHelper = new TenderlyHelper(
+        networkConfig.chainId,
+        networkConfig.tenderly
+      );
+    }
     if (!poolDataService) {
       this.vaultModel = undefined;
     } else {
@@ -61,6 +63,9 @@ export class Simulation {
     const amountsOut: string[] = [];
     switch (simulationType) {
       case SimulationType.Tenderly: {
+        if (!this.tenderlyHelper) {
+          throw new Error('Missing Tenderly config');
+        }
         const simulationResult = await this.tenderlyHelper.simulateMulticall(
           to,
           encodedCall,
@@ -116,6 +121,9 @@ export class Simulation {
     const amountsOut: string[] = [];
     switch (simulationType) {
       case SimulationType.Tenderly: {
+        if (!this.tenderlyHelper) {
+          throw new Error('Missing Tenderly config');
+        }
         const simulationResult = await this.tenderlyHelper.simulateMulticall(
           to,
           encodedCall,

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -46,9 +46,9 @@ export interface BalancerSdkConfig {
 }
 
 export interface BalancerTenderlyConfig {
-  accessKey?: string;
-  user?: string;
-  project?: string;
+  accessKey: string;
+  user: string;
+  project: string;
   blockNumber?: number;
 }
 


### PR DESCRIPTION
This PR removes Tenderly default config and requires custom config to be provided when using Tenderly simulations on generalisedJoin/Exit.