### PR TITLE
GeneralisedJoin - Throw error when decode fails by any reason

### DIFF
--- a/balancer-js/src/modules/simulation/simulation.module.ts
+++ b/balancer-js/src/modules/simulation/simulation.module.ts
@@ -88,18 +88,19 @@ export class Simulation {
           data: encodedCall,
           value,
         });
-        const decodedResponse = Buffer.from(
-          staticResult.split('x')[1],
-          'hex'
-        ).toString('utf8');
-        if (decodedResponse.includes('BAL#')) {
+
+        try {
+          amountsOut.push(...this.decodeResult(staticResult, outputIndexes));
+        } catch (_) {
+          // decoding output failed, so we assume the response contains an error message and try to decode it instead
+          const decodedResponse = Buffer.from(
+            staticResult.split('x')[1],
+            'hex'
+          ).toString('utf8');
           throw new Error(
-            `Transaction reverted with Error ${
-              'BAL#' + decodedResponse.split('BAL#')[1]
-            } on the static call`
+            `Transaction reverted with error: ${decodedResponse}`
           );
         }
-        amountsOut.push(...this.decodeResult(staticResult, outputIndexes));
         break;
       }
       default:
@@ -144,18 +145,18 @@ export class Simulation {
           to,
           data: encodedCall,
         });
-        const decodedResponse = Buffer.from(
-          staticResult.split('x')[1],
-          'hex'
-        ).toString('utf8');
-        if (decodedResponse.includes('BAL#')) {
+        try {
+          amountsOut.push(...this.decodeResult(staticResult, outputIndexes));
+        } catch (_) {
+          // decoding output failed, so we assume the response contains an error message and try to decode it instead
+          const decodedResponse = Buffer.from(
+            staticResult.split('x')[1],
+            'hex'
+          ).toString('utf8');
           throw new Error(
-            `Transaction reverted with Error ${
-              'BAL#' + decodedResponse.split('BAL#')[1]
-            } on the static call`
+            `Transaction reverted with error: ${decodedResponse}`
           );
         }
-        amountsOut.push(...this.decodeResult(staticResult, outputIndexes));
         break;
       }
       default:


### PR DESCRIPTION
According to this ticket on Asana, decode is failing and overflowing, which means the static call didn't succeed.
I updated the code to throw on any kind of error instead of only on the ones that contain "BAL" in it's error message.
It won't fix the issue, but will hopefully help us identify other types of errors that are happening there.