### PR TITLE
Refactor Balancer API fetcher to pull all pools and always use the cache

### DIFF
--- a/balancer-js/src/modules/data/pool/balancer-api.ts
+++ b/balancer-js/src/modules/data/pool/balancer-api.ts
@@ -93,8 +93,6 @@ export class PoolsBalancerAPIRepository
     this.isFetching = true;
     this.hasFetched = true;
 
-    console.log('Doing fetch all');
-
     if (this.nextToken) {
       this.query.args.nextToken = this.nextToken;
     }
@@ -130,13 +128,10 @@ export class PoolsBalancerAPIRepository
   // background, while fetch returns the first results to the user quickly.
   async awaitEnoughPoolsFetched(first: number, skip: number): Promise<void> {
     for (let totalChecks = 0; totalChecks < MAX_CHECKS; totalChecks++) {
-      console.log('Performing check ', totalChecks);
       if (this.pools.length > first + skip) {
-        console.log('Have enough pools, returning');
         return;
       }
       if (!this.isFetching) {
-        console.log('No longer fetching, returning');
         return;
       }
       await timeout(CHECK_INTERVAL_MS);


### PR DESCRIPTION
We had some issues with the Balancer API when filtering pools by token/type, and the root cause of this is that we had a skip variable that we were sometimes using to skip from the API fetch and sometimes to skip from the cache, and this was causing strange things to happen when they were in conflict. 

This PR refactors the Balancer API pool fetcher to always pull all pools, save them to the cache, and return from the cache as soon as enough are available or the query finishes. 