### PR TITLE
add historical capability

### DIFF
--- a/balancer-js/examples/swaps/historicalSwap.ts
+++ b/balancer-js/examples/swaps/historicalSwap.ts
@@ -1,0 +1,73 @@
+import { GraphQLArgs } from '@balancer-labs/sor';
+import { BalancerSDK, formatFixed, parseFixed } from '../../src';
+import { OrderDirection, Pool_OrderBy } from '@/modules/subgraph/subgraph';
+import { BigNumber } from '@ethersproject/bignumber';
+
+const rpcUrl = `https://mainnet.infura.io/v3/${process.env.INFURA}`;
+
+async function historicalSwap() {
+  const balancer = new BalancerSDK({
+    network: 1,
+    rpcUrl: rpcUrl,
+  });
+
+  const swapsService = balancer.swaps;
+  const queryArgWithBlock: GraphQLArgs = {
+    orderBy: Pool_OrderBy.TotalLiquidity,
+    block: {
+      number: 17_000_000,
+    },
+    orderDirection: OrderDirection.Desc,
+    where: {
+      swapEnabled: {
+        eq: true,
+      },
+      totalShares: {
+        gt: 0.000000000001,
+      },
+    },
+  };
+
+  const poolsFetchSuccess = await swapsService.fetchPools(queryArgWithBlock);
+
+  const swapInfo = await swapsService.findRouteGivenIn({
+    tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    amount: parseFixed('1', 18),
+    gasPrice: BigNumber.from('0'),
+    maxPools: 4,
+  });
+
+  const balancerNow = new BalancerSDK({
+    network: 1,
+    rpcUrl: rpcUrl,
+  });
+
+  const swapsServiceNow = balancerNow.swaps;
+
+  const poolsFetchSuccessNow = await swapsServiceNow.fetchPools();
+
+  const swapInfoNow = await swapsServiceNow.findRouteGivenIn({
+    tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+    tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDT
+    amount: parseFixed('1', 18),
+    gasPrice: BigNumber.from('0'),
+    maxPools: 4,
+  });
+
+  console.log(
+    `1 WETH is ${formatFixed(
+      swapInfoNow.returnAmount,
+      6
+    )} USDC using the most recent data`
+  );
+
+  console.log(
+    `1 WETH was ${formatFixed(swapInfo.returnAmount, 6)} USDC at block ${
+      queryArgWithBlock.block?.number
+    }`
+  );
+}
+
+// start with "npm run example -- ./examples/swaps/historicalSwap.ts"
+historicalSwap();

--- a/balancer-js/src/modules/sor/pool-data/onChainData.ts
+++ b/balancer-js/src/modules/sor/pool-data/onChainData.ts
@@ -63,7 +63,8 @@ export async function getOnChainBalances<
   subgraphPoolsOriginal: GenericPool[],
   multiAddress: string,
   vaultAddress: string,
-  provider: Provider
+  provider: Provider,
+  blockNumber?: number
 ): Promise<GenericPool[]> {
   if (subgraphPoolsOriginal.length === 0) return subgraphPoolsOriginal;
 
@@ -87,7 +88,9 @@ export async function getOnChainBalances<
 
   const multicall = Multicall__factory.connect(multiAddress, provider);
 
-  const multiPool = new Multicaller(multicall, abis);
+  const multiPool = blockNumber
+    ? new Multicaller(multicall, abis, { blockTag: blockNumber })
+    : new Multicaller(multicall, abis);
 
   const supportedPoolTypes: string[] = Object.values(PoolType);
   const subgraphPools: GenericPool[] = [];

--- a/balancer-js/src/modules/sor/pool-data/subgraphPoolDataService.ts
+++ b/balancer-js/src/modules/sor/pool-data/subgraphPoolDataService.ts
@@ -95,7 +95,8 @@ export class SubgraphPoolDataService implements PoolDataService {
       mapped,
       this.network.addresses.contracts.multicall,
       this.network.addresses.contracts.vault,
-      this.provider
+      this.provider,
+      queryArgs?.block?.number
     );
 
     logger.timeEnd(`fetching on-chain balances for ${mapped.length} pools`);


### PR DESCRIPTION
Hello Balancer team,

second attempt at adding historical capability to the SDK (see my other PR I made a few hours ago: https://github.com/balancer/balancer-sor/pull/413), this time only without modifying anything on the SOR part.

I figured that the "GraphQLArgs" already had the blockNumber available so I used it to fetch the pools from TheGraph at the block I wanted and used the parameter in "getOnChainBalances" to instantiate the multicaller with the override "blockTag".

This seem to be working but sadly I don't find valid results and I don't know why. You can try with the new example I wrote in examples/swaps/historicalSwaps.ts

when running it here's what is outputted: 

```
1 WETH is 1641.539134 USDC using the most recent data
1 WETH was 2054.066786 USDC at block 17000000
```

While the current value is correct, the one at block 17M is not, should be around 1864 .

What's crazy to me is that my other PR on the SOR does almost the same thing and finds the correct results. I'm still investigating.
