### PR TITLE
Update subgraph urls (moving away from hosted service)

### DIFF
--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -412,7 +412,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.studio.thegraph.com/query/73674/beethovenx-v2-fantom/version/latest',
       gaugesSubgraph: '', // no guages on fantom
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/beethovenxfi/fantom-blocks',
+        'https://api.studio.thegraph.com/query/48427/fantom-blocks/version/latest',
     },
     thirdParty: {
       coingecko: {

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -58,7 +58,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks', // TODO: check if this is still being used and if we have a new endpoint for those
+        'https://api.studio.thegraph.com/query/48427/ethereum-blocks/version/latest⁠',
     },
     thirdParty: {
       coingecko: {
@@ -142,7 +142,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges-polygon/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks', // TODO: same
+        'https://api.studio.thegraph.com/query/48427/polygon-blocks/version/latest',
     },
     thirdParty: {
       coingecko: {
@@ -203,7 +203,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges-arbitrum/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
+        'https://api.studio.thegraph.com/query/48427/arbitrum-blocks/version/latest',
     },
     thirdParty: {
       coingecko: {
@@ -316,7 +316,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges-optimism/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/lyra-finance/optimism-mainnet-blocks',
+        'https://api.studio.thegraph.com/query/48427/optimism-blocks/version/latest',
     },
     pools: {},
     sorConnectingTokens: [
@@ -355,6 +355,8 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.studio.thegraph.com/query/75376/balancer-gnosis-chain-v2/version/latest',
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges-gnosis-chain/version/latest',
+      blockNumberSubgraph:
+        'https://api.studio.thegraph.com/query/48427/gnosis-blocks/version/latest',
     },
     thirdParty: {
       coingecko: {
@@ -547,7 +549,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph:
         'https://api.studio.thegraph.com/query/75376/balancer-gauges-avalanche/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks',
+        'https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest',
     },
     thirdParty: {
       coingecko: {

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -54,11 +54,11 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
+        'https://api.studio.thegraph.com/query/75376/balancer-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+        'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks', // TODO: check if this is still being used and if we have a new endpoint for those
     },
     thirdParty: {
       coingecko: {
@@ -138,11 +138,11 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2',
+        'https://api.studio.thegraph.com/query/75376/balancer-polygon-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges-polygon/version/latest',
       blockNumberSubgraph:
-        'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
+        'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks', // TODO: same
     },
     thirdParty: {
       coingecko: {
@@ -199,9 +199,9 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2',
+        'https://api.studio.thegraph.com/query/75376/balancer-arbitrum-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges-arbitrum/version/latest',
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
     },
@@ -254,7 +254,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2',
+        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2', // TODO: there's no new subgraph for Goerli - should we drop support and remove it entirely?
       gaugesSubgraph:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli',
       blockNumberSubgraph:
@@ -312,9 +312,9 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-optimism',
+        'https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges-optimism/version/latest',
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/lyra-finance/optimism-mainnet-blocks',
     },
@@ -352,9 +352,9 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2',
+        'https://api.studio.thegraph.com/query/75376/balancer-gnosis-chain-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges-gnosis-chain/version/latest',
     },
     thirdParty: {
       coingecko: {
@@ -543,9 +543,9 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2',
+        'https://api.studio.thegraph.com/query/75376/balancer-avalanche-v2/version/latest',
       gaugesSubgraph:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-avalanche',
+        'https://api.studio.thegraph.com/query/75376/balancer-gauges-avalanche/version/latest',
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks',
     },

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -407,7 +407,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     },
     urls: {
       subgraph:
-        'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-v2-fantom',
+        'https://api.studio.thegraph.com/query/73674/beethovenx-v2-fantom/version/latest',
       gaugesSubgraph: '', // no guages on fantom
       blockNumberSubgraph:
         'https://api.thegraph.com/subgraphs/name/beethovenxfi/fantom-blocks',


### PR DESCRIPTION
Closes #580 

Main changes:
- Update `subgraph` and `gaugesSubgraph` config url for all chains

Questions:
- do we still need to support `blockNumbersSubgraph`? -> used to calculate accumulated swapFees on the last 24h
- do we need to push those changes to the master branch and perform a `latest` release?
- I didn't add subgraph info for `Mode` because we don't have any config info for it - do we need to add it?
- I didn't update subgraph info for `Goerli` because we don't have a new one - should we remove all config info for Goerli and drop support for it?